### PR TITLE
feat: Implement openssl as `OpenSSLCrypto` with `crypto-openssl` feature flag.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +242,7 @@ dependencies = [
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsignal-protocol-sys 0.1.0",
  "lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -277,6 +291,31 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "openssl"
+version = "0.10.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +343,11 @@ dependencies = [
 [[package]]
 name = "peeking_take_while"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -592,6 +636,11 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +715,8 @@ dependencies = [
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
@@ -678,9 +729,12 @@ dependencies = [
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+"checksum openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)" = "a51f452b82d622fc8dd973d7266e9055ac64af25b957d9ced3989142dc61cb6b"
+"checksum openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)" = "05636e06b4f8762d4b81d24a351f3966f38bd25ccbcfd235606c91fdb82cc60f"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)" = "64c827cea7a7ab30ce4593e5e04d7a11617ad6ece2fa230605a78b00ff965316"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
@@ -718,6 +772,7 @@ dependencies = [
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"

--- a/libsignal-protocol-sys/tests/smoke_test.rs
+++ b/libsignal-protocol-sys/tests/smoke_test.rs
@@ -1,6 +1,7 @@
 extern crate libsignal_protocol_sys as sys;
 
-use std::{ffi::c_void, ptr, sync::Mutex};
+use std::{ffi::c_void, ptr};
+
 use sys::signal_context;
 
 #[test]

--- a/libsignal-protocol/Cargo.toml
+++ b/libsignal-protocol/Cargo.toml
@@ -13,3 +13,6 @@ failure_derive = "0.1.5"
 rand = "0.6.5"
 parking_lot = "0.8.0"
 lock_api = "0.2.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+openssl = "0.10"

--- a/libsignal-protocol/Cargo.toml
+++ b/libsignal-protocol/Cargo.toml
@@ -13,6 +13,9 @@ failure_derive = "0.1.5"
 rand = "0.6.5"
 parking_lot = "0.8.0"
 lock_api = "0.2.0"
+openssl = { version = "0.10", optional = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
-openssl = "0.10"
+[features]
+default = ["crypto-native"]
+crypto-native = [] # TODO(shekohex): add this feature.
+crypto-openssl = ["openssl"]

--- a/libsignal-protocol/examples/generate_keys.rs
+++ b/libsignal-protocol/examples/generate_keys.rs
@@ -28,7 +28,7 @@ use libsignal_protocol::{Context, DefaultCrypto};
 use std::time::SystemTime;
 
 fn main() -> Result<(), Error> {
-    let ctx = Context::new(DefaultCrypto)?;
+    let ctx = Context::new(DefaultCrypto::default())?;
     let extended_range = 0;
     let start = 123;
     let pre_key_count = 20;

--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Error> {
     let addr = Address::new("+14159998888", 1);
 
     // Instantiate a session_builder for a recipient address.
-    let session_builder = SessionBuilder::new(ctx, store_ctx, addr);
+    let _session_builder = SessionBuilder::new(ctx, store_ctx, addr);
 
     Ok(())
 }

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -134,7 +134,7 @@ impl Context {
 
 impl Default for Context {
     fn default() -> Context {
-        match Context::new(DefaultCrypto) {
+        match Context::new(DefaultCrypto::default()) {
             Ok(c) => c,
             Err(e) => {
                 panic!("Unable to create a context using the defaults: {}", e)
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn library_initialization_example_from_readme() {
-        let ctx = Context::new(DefaultCrypto).unwrap();
+        let ctx = Context::new(DefaultCrypto::default()).unwrap();
 
         drop(ctx);
     }

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -5,8 +5,10 @@ use parking_lot::RawMutex;
 
 use sys::signal_context;
 
+#[cfg(feature = "crypto-native")]
+use crate::crypto::DefaultCrypto;
 use crate::{
-    crypto::{Crypto, CryptoProvider, DefaultCrypto},
+    crypto::{Crypto, CryptoProvider},
     errors::{FromInternalErrorCode, InternalError},
     identity_key_store::{self as iks, IdentityKeyStore},
     keys::{IdentityKeyPair, PreKeyList},
@@ -134,6 +136,7 @@ impl Context {
     pub(crate) fn raw(&self) -> *mut sys::signal_context { self.0.raw() }
 }
 
+#[cfg(feature = "crypto-native")]
 impl Default for Context {
     fn default() -> Context {
         match Context::new(DefaultCrypto::default()) {
@@ -229,7 +232,7 @@ struct State {
     mux: RawMutex,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "crypto-native"))]
 mod tests {
     use super::*;
 

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -1,6 +1,13 @@
+use std::{ffi::c_void, pin::Pin, ptr, rc::Rc};
+
+use lock_api::RawMutex as _;
+use parking_lot::RawMutex;
+
+use sys::signal_context;
+
 use crate::{
     crypto::{Crypto, CryptoProvider, DefaultCrypto},
-    errors::{InternalError, InternalErrorCode},
+    errors::{FromInternalErrorCode, InternalError},
     identity_key_store::{self as iks, IdentityKeyStore},
     keys::{IdentityKeyPair, PreKeyList},
     pre_key_store::{self as pks, PreKeyStore},
@@ -9,11 +16,6 @@ use crate::{
     store_context::StoreContext,
     Wrapped,
 };
-
-use lock_api::RawMutex as _;
-use parking_lot::RawMutex;
-use std::{ffi::c_void, pin::Pin, ptr, rc::Rc};
-use sys::signal_context;
 
 pub struct Context(pub(crate) Rc<ContextInner>);
 

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -12,17 +12,13 @@ use crate::{
     errors::{FromInternalErrorCode, InternalError},
     identity_key_store::{self as iks, IdentityKeyStore},
     keys::{IdentityKeyPair, KeyPair, PreKeyList},
+    pre_key::PreKey,
     pre_key_store::{self as pks, PreKeyStore},
     session_store::{self as sess, SessionStore},
     signed_pre_key_store::{self as spks, SignedPreKeyStore},
     store_context::StoreContext,
-    PreKey, PreKeyBundle, PreKeyBundleBuilder, Wrapped,
+    PreKeyBundle, PreKeyBundleBuilder, Wrapped,
 };
-
-use lock_api::RawMutex as _;
-use parking_lot::RawMutex;
-use std::{ffi::c_void, pin::Pin, ptr, rc::Rc};
-use sys::signal_context;
 
 /// Global state and callbacks used by the library.
 pub struct Context(pub(crate) Rc<ContextInner>);

--- a/libsignal-protocol/src/crypto.rs
+++ b/libsignal-protocol/src/crypto.rs
@@ -1,23 +1,266 @@
-use rand::RngCore;
+use crate::{
+    buffer::Buffer,
+    errors::{InternalError, InternalErrorCode},
+};
 use std::{
     os::raw::{c_int, c_void},
     pin::Pin,
     slice,
 };
 use sys::{signal_buffer, signal_crypto_provider};
-
-/// Cryptography routines used in the signal protocol.
-pub trait Crypto {
-    fn fill_random(&self, buffer: &mut [u8]);
+pub enum SignalCipherType {
+    AesCtrNoPadding,
+    AesCbcPkcs5,
 }
 
+impl From<i32> for SignalCipherType {
+    fn from(v: i32) -> Self {
+        match v as u32 {
+            sys::SG_CIPHER_AES_CTR_NOPADDING => {
+                SignalCipherType::AesCtrNoPadding
+            },
+            sys::SG_CIPHER_AES_CBC_PKCS5 => SignalCipherType::AesCbcPkcs5,
+            _ => unimplemented!("Unimplemented Signal Cipher Type"),
+        }
+    }
+}
+/// Cryptography routines used in the signal protocol.
+pub trait Crypto {
+    fn fill_random(&self, buffer: &mut [u8]) -> Result<(), InternalError>;
+    fn hmac_sha256_init(&mut self, key: &[u8]) -> Result<(), InternalError>;
+    fn hmac_sha256_update(&mut self, data: &[u8]) -> Result<(), InternalError>;
+    fn hmac_sha256_final(&mut self) -> Result<Vec<u8>, InternalError>;
+    fn hmac_sha256_cleanup(&mut self) {}
+
+    fn sha512_digest_init(&mut self) -> Result<(), InternalError>;
+    fn sha512_digest_update(
+        &mut self,
+        data: &[u8],
+    ) -> Result<(), InternalError>;
+    fn sha512_digest_final(&mut self) -> Result<Vec<u8>, InternalError>;
+    fn sha512_digest_cleanup(&mut self) {}
+
+    fn encrypt(
+        &self,
+        cipher: SignalCipherType,
+        key: &[u8],
+        iv: &[u8],
+        data: &[u8],
+    ) -> Result<Vec<u8>, InternalError>;
+    fn decrypt(
+        &self,
+        cipher: SignalCipherType,
+        key: &[u8],
+        iv: &[u8],
+        data: &[u8],
+    ) -> Result<Vec<u8>, InternalError>;
+}
+
+#[cfg(not(target_os = "linux"))]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct DefaultCrypto;
 
+#[cfg(target_os = "linux")]
+#[derive(Clone)]
+pub struct DefaultCrypto {
+    hmac_ctx: Option<openssl::hash::Hasher>,
+    sha512_ctx: Option<openssl::hash::Hasher>,
+}
+
+#[cfg(not(target_os = "linux"))]
 impl Crypto for DefaultCrypto {
-    fn fill_random(&self, buffer: &mut [u8]) {
+    fn fill_random(&self, buffer: &mut [u8]) -> Result<(), InternalError> {
+        use rand::RngCore;
         let mut rng = rand::thread_rng();
         rng.fill_bytes(buffer);
+        Ok(())
+    }
+
+    fn hmac_sha256_init(&mut self, key: &[u8]) -> Result<(), InternalError> {
+        unimplemented!()
+    }
+
+    fn hmac_sha256_update(&mut self, data: &[u8]) -> Result<(), InternalError> {
+        unimplemented!()
+    }
+
+    fn hmac_sha256_final(&mut self) -> Result<Vec<u8>, InternalError> {
+        unimplemented!()
+    }
+
+    fn sha512_digest_init(&mut self) -> Result<(), InternalError> {
+        unimplemented!()
+    }
+
+    fn sha512_digest_update(
+        &mut self,
+        data: &[u8],
+    ) -> Result<(), InternalError> {
+        unimplemented!()
+    }
+
+    fn sha512_digest_final(&mut self) -> Result<Vec<u8>, InternalError> {
+        unimplemented!()
+    }
+
+    fn encrypt(
+        &self,
+        cipher: SignalCipherType,
+        key: &[u8],
+        iv: &[u8],
+        data: &[u8],
+    ) -> Result<Vec<u8>, InternalError> {
+        unimplemented!()
+    }
+
+    fn decrypt(
+        &self,
+        cipher: SignalCipherType,
+        key: &[u8],
+        iv: &[u8],
+        data: &[u8],
+    ) -> Result<Vec<u8>, InternalError> {
+        unimplemented!()
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+impl Default for DefaultCrypto {
+    fn default() -> Self { Self }
+}
+
+#[cfg(target_os = "linux")]
+impl Default for DefaultCrypto {
+    fn default() -> Self {
+        Self {
+            hmac_ctx: None,
+            sha512_ctx: None,
+        }
+    }
+}
+#[cfg(target_os = "linux")]
+impl DefaultCrypto {
+    pub fn crypter(
+        &self,
+        mode: openssl::symm::Mode,
+        cipher: SignalCipherType,
+        key: &[u8],
+        iv: &[u8],
+        data: &[u8],
+    ) -> Result<Vec<u8>, InternalError> {
+        use openssl::symm::{Cipher, Crypter};
+        use SignalCipherType::*;
+        let signal_cipher_type = match (cipher, key.len()) {
+            (AesCtrNoPadding, 16) => Cipher::aes_128_ctr(),
+            (AesCtrNoPadding, 24) => {
+                let nid = openssl::nid::Nid::AES_192_CTR;
+                Cipher::from_nid(nid)
+                    .expect("OpenSSL should have AES_192_CTR !!")
+            },
+            (AesCtrNoPadding, 32) => Cipher::aes_256_ctr(),
+            (AesCbcPkcs5, 16) => Cipher::aes_128_cbc(),
+            (AesCbcPkcs5, 24) => {
+                let nid = openssl::nid::Nid::AES_192_CBC;
+                Cipher::from_nid(nid)
+                    .expect("OpenSSL should have AES_192_CBC !!")
+            },
+            (AesCbcPkcs5, 32) => Cipher::aes_256_cbc(),
+            _ => unreachable!(),
+        };
+        let block_size = signal_cipher_type.block_size();
+        let mut result = Vec::with_capacity(data.len() + block_size);
+        let mut crypter = Crypter::new(signal_cipher_type, mode, key, Some(iv))
+            .map_err(|_e| InternalError::Unknown)?;
+        crypter
+            .update(data, &mut result)
+            .map_err(|_e| InternalError::Unknown)?;
+        crypter
+            .finalize(&mut result)
+            .map_err(|_e| InternalError::Unknown)?;
+        Ok(result)
+    }
+}
+#[cfg(target_os = "linux")]
+impl Crypto for DefaultCrypto {
+    fn fill_random(&self, buffer: &mut [u8]) -> Result<(), InternalError> {
+        openssl::rand::rand_bytes(buffer).map_err(|_e| InternalError::Unknown)
+    }
+
+    fn hmac_sha256_init(&mut self, _key: &[u8]) -> Result<(), InternalError> {
+        let nid = openssl::nid::Nid::HMACWITHSHA256;
+        let ty = openssl::hash::MessageDigest::from_nid(nid)
+            .ok_or_else(|| InternalError::Unknown)?;
+        let ctx = openssl::hash::Hasher::new(ty)
+            .map_err(|_e| InternalError::Unknown)?;
+        self.hmac_ctx = Some(ctx);
+        Ok(())
+    }
+
+    fn hmac_sha256_update(&mut self, data: &[u8]) -> Result<(), InternalError> {
+        if let Some(ref mut ctx) = self.hmac_ctx {
+            ctx.update(data).map_err(|_e| InternalError::Unknown)?;
+        }
+        Ok(())
+    }
+
+    fn hmac_sha256_final(&mut self) -> Result<Vec<u8>, InternalError> {
+        if let Some(ref mut ctx) = self.hmac_ctx {
+            ctx.finish()
+                .map(|buf| buf.as_ref().to_owned())
+                .map_err(|_e| InternalError::Unknown)
+        } else {
+            Err(InternalError::Unknown)
+        }
+    }
+
+    fn sha512_digest_init(&mut self) -> Result<(), InternalError> {
+        let ty = openssl::hash::MessageDigest::sha512();
+        let ctx = openssl::hash::Hasher::new(ty)
+            .map_err(|_e| InternalError::Unknown)?;
+        self.sha512_ctx = Some(ctx);
+        Ok(())
+    }
+
+    fn sha512_digest_update(
+        &mut self,
+        data: &[u8],
+    ) -> Result<(), InternalError> {
+        if let Some(ref mut ctx) = self.sha512_ctx {
+            ctx.update(data).map_err(|_e| InternalError::Unknown)?;
+        }
+        Ok(())
+    }
+
+    fn sha512_digest_final(&mut self) -> Result<Vec<u8>, InternalError> {
+        if let Some(ref mut ctx) = self.sha512_ctx {
+            ctx.finish()
+                .map(|buf| buf.as_ref().to_owned())
+                .map_err(|_e| InternalError::Unknown)
+        } else {
+            Err(InternalError::Unknown)
+        }
+    }
+
+    fn encrypt(
+        &self,
+        cipher: SignalCipherType,
+        key: &[u8],
+        iv: &[u8],
+        data: &[u8],
+    ) -> Result<Vec<u8>, InternalError> {
+        use openssl::symm::Mode;
+        self.crypter(Mode::Encrypt, cipher, key, iv, data)
+    }
+
+    fn decrypt(
+        &self,
+        cipher: SignalCipherType,
+        key: &[u8],
+        iv: &[u8],
+        data: &[u8],
+    ) -> Result<Vec<u8>, InternalError> {
+        use openssl::symm::Mode;
+        self.crypter(Mode::Decrypt, cipher, key, iv, data)
     }
 }
 
@@ -35,17 +278,17 @@ impl CryptoProvider {
 
         let vtable = signal_crypto_provider {
             user_data: state.as_mut().get_mut() as *mut State as *mut c_void,
-            decrypt_func: None,
-            encrypt_func: None,
-            hmac_sha256_cleanup_func: Some(hmac_sha256_cleanup_func),
-            hmac_sha256_final_func: Some(hmac_sha256_final_func),
+            random_func: Some(random_func),
             hmac_sha256_init_func: Some(hmac_sha256_init_func),
             hmac_sha256_update_func: Some(hmac_sha256_update_func),
-            sha512_digest_cleanup_func: None,
-            random_func: Some(random_func),
-            sha512_digest_final_func: None,
-            sha512_digest_init_func: None,
-            sha512_digest_update_func: None,
+            hmac_sha256_final_func: Some(hmac_sha256_final_func),
+            hmac_sha256_cleanup_func: Some(hmac_sha256_cleanup_func),
+            sha512_digest_init_func: Some(sha512_digest_init_func),
+            sha512_digest_update_func: Some(sha512_digest_update_func),
+            sha512_digest_final_func: Some(sha512_digest_final_func),
+            sha512_digest_cleanup_func: Some(sha512_digest_cleanup_func),
+            encrypt_func: Some(encrypt_func),
+            decrypt_func: Some(decrypt_func),
         };
 
         CryptoProvider { vtable, state }
@@ -55,39 +298,6 @@ impl CryptoProvider {
 }
 
 struct State(Box<dyn Crypto>);
-
-unsafe extern "C" fn hmac_sha256_cleanup_func(
-    _hmac_context: *mut c_void,
-    _user_data: *mut c_void,
-) {
-    unimplemented!();
-}
-
-unsafe extern "C" fn hmac_sha256_final_func(
-    _hmac_context: *mut c_void,
-    _output: *mut *mut signal_buffer,
-    _user_data: *mut c_void,
-) -> i32 {
-    unimplemented!()
-}
-
-unsafe extern "C" fn hmac_sha256_init_func(
-    _hmac_context: *mut *mut c_void,
-    _key: *const u8,
-    _key_len: usize,
-    _user_data: *mut c_void,
-) -> i32 {
-    unimplemented!()
-}
-
-unsafe extern "C" fn hmac_sha256_update_func(
-    _hmac_context: *mut c_void,
-    _data: *const u8,
-    _data_len: usize,
-    _user_data: *mut c_void,
-) -> i32 {
-    unimplemented!()
-}
 
 unsafe extern "C" fn random_func(
     data: *mut u8,
@@ -99,6 +309,175 @@ unsafe extern "C" fn random_func(
 
     let user_data = &*(user_data as *const State);
     let buffer = slice::from_raw_parts_mut(data, len);
-    user_data.0.fill_random(buffer);
-    0
+    user_data.0.fill_random(buffer).into_code()
+}
+
+unsafe extern "C" fn hmac_sha256_cleanup_func(
+    _hmac_context: *mut c_void,
+    user_data: *mut c_void,
+) {
+    assert!(!user_data.is_null());
+
+    let user_data = &mut *(user_data as *mut State);
+    user_data.0.hmac_sha256_cleanup();
+}
+
+unsafe extern "C" fn hmac_sha256_final_func(
+    _hmac_context: *mut c_void,
+    output: *mut *mut signal_buffer,
+    user_data: *mut c_void,
+) -> i32 {
+    assert!(!user_data.is_null());
+
+    let user_data = &mut *(user_data as *mut State);
+    match user_data.0.hmac_sha256_final() {
+        Ok(buf) => {
+            let buffer = Buffer::from(buf);
+            output.write(buffer.into_raw());
+            sys::SG_SUCCESS as c_int
+        },
+        Err(e) => e.code(),
+    }
+}
+
+unsafe extern "C" fn hmac_sha256_init_func(
+    _hmac_context: *mut *mut c_void,
+    key: *const u8,
+    key_len: usize,
+    user_data: *mut c_void,
+) -> i32 {
+    assert!(!key.is_null());
+    assert!(!user_data.is_null());
+
+    let user_data = &mut *(user_data as *mut State);
+    let buffer = slice::from_raw_parts(key, key_len);
+    user_data.0.hmac_sha256_init(buffer).into_code()
+}
+
+unsafe extern "C" fn hmac_sha256_update_func(
+    _hmac_context: *mut c_void,
+    data: *const u8,
+    data_len: usize,
+    user_data: *mut c_void,
+) -> i32 {
+    assert!(!data.is_null());
+    assert!(!user_data.is_null());
+
+    let user_data = &mut *(user_data as *mut State);
+    let buffer = slice::from_raw_parts(data, data_len);
+    user_data.0.hmac_sha256_update(buffer).into_code()
+}
+
+unsafe extern "C" fn sha512_digest_init_func(
+    _digest_context: *mut *mut c_void,
+    user_data: *mut c_void,
+) -> c_int {
+    assert!(!user_data.is_null());
+
+    let user_data = &mut *(user_data as *mut State);
+    user_data.0.sha512_digest_init().into_code()
+}
+
+unsafe extern "C" fn sha512_digest_update_func(
+    _digest_context: *mut c_void,
+    data: *const u8,
+    data_len: usize,
+    user_data: *mut c_void,
+) -> c_int {
+    assert!(!data.is_null());
+    assert!(!user_data.is_null());
+
+    let user_data = &mut *(user_data as *mut State);
+    let buffer = slice::from_raw_parts(data, data_len);
+    user_data.0.sha512_digest_update(buffer).into_code()
+}
+
+unsafe extern "C" fn sha512_digest_final_func(
+    _digest_context: *mut c_void,
+    output: *mut *mut signal_buffer,
+    user_data: *mut c_void,
+) -> c_int {
+    assert!(!user_data.is_null());
+
+    let user_data = &mut *(user_data as *mut State);
+    match user_data.0.sha512_digest_final() {
+        Ok(buf) => {
+            let buffer = Buffer::from(buf);
+            output.write(buffer.into_raw());
+            sys::SG_SUCCESS as c_int
+        },
+        Err(e) => e.code(),
+    }
+}
+
+unsafe extern "C" fn sha512_digest_cleanup_func(
+    _digest_context: *mut c_void,
+    user_data: *mut c_void,
+) {
+    assert!(!user_data.is_null());
+
+    let user_data = &mut *(user_data as *mut State);
+    user_data.0.sha512_digest_cleanup();
+}
+
+unsafe extern "C" fn encrypt_func(
+    output: *mut *mut signal_buffer,
+    cipher: c_int,
+    key: *const u8,
+    key_len: usize,
+    iv: *const u8,
+    iv_len: usize,
+    plaintext: *const u8,
+    plaintext_len: usize,
+    user_data: *mut c_void,
+) -> c_int {
+    assert!(!user_data.is_null());
+    assert!(!key.is_null());
+    assert!(!iv.is_null());
+    assert!(!plaintext.is_null());
+
+    let key = slice::from_raw_parts(key, key_len);
+    let iv = slice::from_raw_parts(iv, iv_len);
+    let data = slice::from_raw_parts(plaintext, plaintext_len);
+    let signal_cipher_type = SignalCipherType::from(cipher);
+    let user_data = &mut *(user_data as *mut State);
+    match user_data.0.encrypt(signal_cipher_type, key, iv, data) {
+        Ok(buf) => {
+            let buffer = Buffer::from(buf);
+            output.write(buffer.into_raw());
+            sys::SG_SUCCESS as c_int
+        },
+        Err(e) => e.code(),
+    }
+}
+
+unsafe extern "C" fn decrypt_func(
+    output: *mut *mut signal_buffer,
+    cipher: c_int,
+    key: *const u8,
+    key_len: usize,
+    iv: *const u8,
+    iv_len: usize,
+    ciphertext: *const u8,
+    ciphertext_len: usize,
+    user_data: *mut c_void,
+) -> c_int {
+    assert!(!user_data.is_null());
+    assert!(!key.is_null());
+    assert!(!iv.is_null());
+    assert!(!ciphertext.is_null());
+
+    let key = slice::from_raw_parts(key, key_len);
+    let iv = slice::from_raw_parts(iv, iv_len);
+    let data = slice::from_raw_parts(ciphertext, ciphertext_len);
+    let signal_cipher_type = SignalCipherType::from(cipher);
+    let user_data = &mut *(user_data as *mut State);
+    match user_data.0.decrypt(signal_cipher_type, key, iv, data) {
+        Ok(buf) => {
+            let buffer = Buffer::from(buf);
+            output.write(buffer.into_raw());
+            sys::SG_SUCCESS as c_int
+        },
+        Err(e) => e.code(),
+    }
 }

--- a/libsignal-protocol/src/crypto.rs
+++ b/libsignal-protocol/src/crypto.rs
@@ -90,11 +90,11 @@ impl Crypto for DefaultCrypto {
         Ok(())
     }
 
-    fn hmac_sha256_init(&self, key: &[u8]) -> Result<(), InternalError> {
+    fn hmac_sha256_init(&self, _key: &[u8]) -> Result<(), InternalError> {
         unimplemented!()
     }
 
-    fn hmac_sha256_update(&self, data: &[u8]) -> Result<(), InternalError> {
+    fn hmac_sha256_update(&self, _data: &[u8]) -> Result<(), InternalError> {
         unimplemented!()
     }
 
@@ -106,7 +106,7 @@ impl Crypto for DefaultCrypto {
         unimplemented!()
     }
 
-    fn sha512_digest_update(&self, data: &[u8]) -> Result<(), InternalError> {
+    fn sha512_digest_update(&self, _data: &[u8]) -> Result<(), InternalError> {
         unimplemented!()
     }
 
@@ -116,20 +116,20 @@ impl Crypto for DefaultCrypto {
 
     fn encrypt(
         &self,
-        cipher: SignalCipherType,
-        key: &[u8],
-        iv: &[u8],
-        data: &[u8],
+        _cipher: SignalCipherType,
+        _key: &[u8],
+        _iv: &[u8],
+        _data: &[u8],
     ) -> Result<Vec<u8>, InternalError> {
         unimplemented!()
     }
 
     fn decrypt(
         &self,
-        cipher: SignalCipherType,
-        key: &[u8],
-        iv: &[u8],
-        data: &[u8],
+        _cipher: SignalCipherType,
+        _key: &[u8],
+        _iv: &[u8],
+        _data: &[u8],
     ) -> Result<Vec<u8>, InternalError> {
         unimplemented!()
     }

--- a/libsignal-protocol/src/crypto.rs
+++ b/libsignal-protocol/src/crypto.rs
@@ -10,7 +10,7 @@ use sys::{signal_buffer, signal_crypto_provider};
 
 use crate::{
     buffer::Buffer,
-    errors::{InternalError, InternalErrorCode},
+    errors::{InternalError, IntoInternalErrorCode},
 };
 
 #[derive(Debug, Clone)]

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -98,12 +98,15 @@ impl InternalError {
     }
 }
 
-pub(crate) trait InternalErrorCode: Sized {
+pub(crate) trait FromInternalErrorCode: Sized {
     fn into_result(self) -> Result<(), InternalError>;
+}
+
+pub(crate) trait IntoInternalErrorCode: Sized {
     fn into_code(self) -> i32;
 }
 
-impl InternalErrorCode for i32 {
+impl FromInternalErrorCode for i32 {
     fn into_result(self) -> Result<(), InternalError> {
         if self == 0 {
             return Ok(());
@@ -114,16 +117,9 @@ impl InternalErrorCode for i32 {
             Some(e) => Err(e),
         }
     }
-
-    fn into_code(self) -> i32 { self }
 }
 
-impl<T> InternalErrorCode for Result<T, InternalError>
-where
-    T: Any,
-{
-    fn into_result(self) -> Result<(), InternalError> { self.map(|_| ()) }
-
+impl<T> IntoInternalErrorCode for Result<T, InternalError> {
     fn into_code(self) -> i32 {
         match self {
             Ok(_) => 0,

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -1,4 +1,3 @@
-use core::any::Any;
 use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, failure_derive::Fail)]

--- a/libsignal-protocol/src/keys.rs
+++ b/libsignal-protocol/src/keys.rs
@@ -1,5 +1,3 @@
-use crate::{context::ContextInner, errors::InternalErrorCode, Wrapped};
-use failure::Error;
 use std::{
     marker::PhantomData,
     ptr,
@@ -7,7 +5,12 @@ use std::{
     slice,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+use failure::Error;
+
 use sys::AsSignalTypeBase;
+
+use crate::{context::ContextInner, errors::FromInternalErrorCode, Wrapped};
 
 pub struct IdentityKeyPair {
     raw: *mut sys::ratchet_identity_key_pair,

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -60,11 +60,18 @@ pub use crate::crypto::DefaultCrypto;
 #[cfg(feature = "crypto-openssl")]
 pub use crate::crypto::OpenSSLCrypto;
 pub use crate::{
-    address::Address, buffer::Buffer, context::Context, crypto::Crypto,
-    errors::InternalError, identity_key_store::IdentityKeyStore,
-    pre_key_bundle::{PreKeyBundle, PreKeyBundleBuilder}, pre_key_store::PreKeyStore,
-    session_builder::SessionBuilder, session_store::SessionStore,
-    signed_pre_key_store::SignedPreKeyStore, store_context::StoreContext,
+    address::Address,
+    buffer::Buffer,
+    context::Context,
+    crypto::Crypto,
+    errors::InternalError,
+    identity_key_store::IdentityKeyStore,
+    pre_key_bundle::{PreKeyBundle, PreKeyBundleBuilder},
+    pre_key_store::PreKeyStore,
+    session_builder::SessionBuilder,
+    session_store::SessionStore,
+    signed_pre_key_store::SignedPreKeyStore,
+    store_context::StoreContext,
 };
 
 #[macro_use]

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -1,5 +1,20 @@
 extern crate libsignal_protocol_sys as sys;
 
+use std::rc::Rc;
+
+use crate::context::ContextInner;
+#[cfg(feature = "crypto-native")]
+pub use crate::crypto::DefaultCrypto;
+#[cfg(feature = "crypto-openssl")]
+pub use crate::crypto::OpenSSLCrypto;
+pub use crate::{
+    address::Address, buffer::Buffer, context::Context, crypto::Crypto,
+    errors::InternalError, identity_key_store::IdentityKeyStore,
+    pre_key_bundle::PreKeyBundle, pre_key_store::PreKeyStore,
+    session_builder::SessionBuilder, session_store::SessionStore,
+    signed_pre_key_store::SignedPreKeyStore, store_context::StoreContext,
+};
+
 #[macro_use]
 mod macros;
 mod address;
@@ -15,24 +30,6 @@ mod session_builder;
 mod session_store;
 mod signed_pre_key_store;
 mod store_context;
-
-pub use crate::{
-    address::Address,
-    buffer::Buffer,
-    context::Context,
-    crypto::{Crypto, DefaultCrypto},
-    errors::InternalError,
-    identity_key_store::IdentityKeyStore,
-    pre_key_bundle::PreKeyBundle,
-    pre_key_store::PreKeyStore,
-    session_builder::SessionBuilder,
-    session_store::SessionStore,
-    signed_pre_key_store::SignedPreKeyStore,
-    store_context::StoreContext,
-};
-
-use crate::context::ContextInner;
-use std::rc::Rc;
 
 pub(crate) trait Wrapped: Sized {
     type Raw: ?Sized;


### PR DESCRIPTION
I implemented All the methods from `Crypto` trait for `OpenSSLCrypto` using OpenSSL crate.
Also `CryptoProvider` has now full binding for the backed trampoline functions provided from `Crypto` trait.

I was wonder if i could see how to add some tests for this implementation, to make sure everything is working fine and in its place.

Next i would start to implement a Native Rust one for other platforms, since MacOS (CommonCrypto) binding in rust, is not that easy to use, same goes for Windows (CryptoAPI), but i will try, see #2 
