### PR TITLE
TellTravis it can ignore nightly failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: rust
 sudo: false
 cache: cargo
 
-rust:
-  - 1.34.0
-  - stable
-
 script: 
   - cargo build --all --verbose
   - cargo test --all --verbose
@@ -18,6 +14,8 @@ before_deploy:
 
 matrix:
   include:
+    - rust: stable
+    - rust: 1.34.0
     - rust: nightly
       before_script:
         - rustup component add rustfmt
@@ -25,6 +23,8 @@ matrix:
       script:
         - cargo fmt --all -- --check
         - cargo clippy -- -D clippy::all
+  allow_failures:
+    - rust: nightly
 
 deploy:
   provider: pages


### PR DESCRIPTION
Builds are currently failing because `clippy` won't install on `nightly`. This temporarily allows failures on the `nightly` build to avoid the spurious failures.

See https://travis-ci.com/Michael-F-Bryan/libsignal-protocol-rs/jobs/200001104