### PR TITLE
Turn all context methods into free functions

### DIFF
--- a/libsignal-protocol/examples/generate_keys.rs
+++ b/libsignal-protocol/examples/generate_keys.rs
@@ -23,8 +23,10 @@
 //!
 //! cit: https://github.com/signalapp/libsignal-protocol-c#client-install-time
 
+extern crate libsignal_protocol as sig;
+
 use failure::Error;
-use libsignal_protocol::Context;
+use sig::Context;
 use std::time::SystemTime;
 
 fn main() -> Result<(), Error> {
@@ -33,19 +35,23 @@ fn main() -> Result<(), Error> {
     let start = 123;
     let pre_key_count = 20;
 
-    let identity_key_pair = ctx.generate_identity_key_pair()?;
-    let signed_pre_key =
-        ctx.generate_signed_pre_key(&identity_key_pair, 5, SystemTime::now())?;
+    let identity_key_pair = sig::generate_identity_key_pair(&ctx)?;
+    let signed_pre_key = sig::generate_signed_pre_key(
+        &ctx,
+        &identity_key_pair,
+        5,
+        SystemTime::now(),
+    )?;
     println!(
         "Signed pre key ID: {} at {:?}",
         signed_pre_key.id(),
         signed_pre_key.timestamp()
     );
 
-    let registration_id = ctx.generate_registration_id(extended_range)?;
+    let registration_id = sig::generate_registration_id(&ctx, extended_range)?;
     println!("Registration ID: {}", registration_id);
 
-    let pre_keys = ctx.generate_pre_keys(start, pre_key_count)?;
+    let pre_keys = sig::generate_pre_keys(&ctx, start, pre_key_count)?;
 
     let pre_key_ids: Vec<_> = pre_keys
         .iter()

--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -43,6 +43,8 @@
 //!
 //! [bas]: https://github.com/signalapp/libsignal-protocol-c#building-a-session
 
+extern crate libsignal_protocol as sig;
+
 #[path = "../tests/helpers/mod.rs"]
 mod helpers;
 
@@ -51,7 +53,7 @@ use self::helpers::{
     BasicSignedPreKeyStore,
 };
 use failure::{Error, ResultExt};
-use libsignal_protocol::{
+use sig::{
     Address, Context, PreKeyBundle, Serializable, SessionBuilder, SessionCipher,
 };
 use std::time::SystemTime;
@@ -61,22 +63,25 @@ fn main() -> Result<(), Error> {
 
     // first we'll need a copy of bob's public key and some of his pre-keys
     let bob_address = Address::new("+14159998888", 1);
-    let bob_identity_keys = ctx
-        .generate_identity_key_pair()
+    let bob_identity_keys = sig::generate_identity_key_pair(&ctx)
         .context("Unable to generate bob's keys")?;
     let bob_public_identity_key = bob_identity_keys.public()?;
-    let bob_pre_keys: Vec<_> = ctx
-        .generate_pre_keys(0, 10)
+    let bob_pre_keys: Vec<_> = sig::generate_pre_keys(&ctx, 0, 10)
         .context("Unable to generate bob's pre-keys")?
         .iter()
         .collect();
     let pre_key = &bob_pre_keys[0];
-    let bob_signed_pre_key = ctx
-        .generate_signed_pre_key(&bob_identity_keys, 12, SystemTime::now())
-        .context("Unable to generate a signed pre-key for bob")?;
+    let bob_signed_pre_key = sig::generate_signed_pre_key(
+        &ctx,
+        &bob_identity_keys,
+        12,
+        SystemTime::now(),
+    )
+    .context("Unable to generate a signed pre-key for bob")?;
 
     // set up some key stores for alice
-    let alice_store_ctx = ctx.store_context(
+    let alice_store_ctx = sig::store_context(
+        &ctx,
         BasicPreKeyStore::default(),
         BasicSignedPreKeyStore::default(),
         BasicSessionStore::default(),

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -29,6 +29,183 @@ use crate::{
     Address, Buffer, StoreContext,
 };
 
+pub fn generate_identity_key_pair(
+    ctx: &Context,
+) -> Result<IdentityKeyPair, Error> {
+    unsafe {
+        let mut key_pair = ptr::null_mut();
+        sys::signal_protocol_key_helper_generate_identity_key_pair(
+            &mut key_pair,
+            ctx.raw(),
+        )
+        .into_result()?;
+        Ok(IdentityKeyPair {
+            raw: Raw::from_ptr(key_pair),
+        })
+    }
+}
+
+pub fn generate_key_pair(ctx: &Context) -> Result<KeyPair, Error> {
+    unsafe {
+        let mut key_pair = ptr::null_mut();
+        sys::curve_generate_key_pair(ctx.raw(), &mut key_pair).into_result()?;
+
+        Ok(KeyPair {
+            raw: Raw::from_ptr(key_pair),
+        })
+    }
+}
+
+pub fn calculate_signature(
+    ctx: &Context,
+    private: &PrivateKey,
+    message: &[u8],
+) -> Result<Buffer, Error> {
+    unsafe {
+        let mut buffer = ptr::null_mut();
+        sys::curve_calculate_signature(
+            ctx.raw(),
+            &mut buffer,
+            private.raw.as_const_ptr(),
+            message.as_ptr(),
+            message.len(),
+        )
+        .into_result()?;
+
+        Ok(Buffer::from_raw(buffer))
+    }
+}
+
+pub fn generate_registration_id(
+    ctx: &Context,
+    extended_range: i32,
+) -> Result<u32, Error> {
+    let mut id = 0;
+    unsafe {
+        sys::signal_protocol_key_helper_generate_registration_id(
+            &mut id,
+            extended_range,
+            ctx.raw(),
+        )
+        .into_result()?;
+    }
+
+    Ok(id)
+}
+
+pub fn generate_pre_keys(
+    ctx: &Context,
+    start: u32,
+    count: u32,
+) -> Result<PreKeyList, Error> {
+    unsafe {
+        let mut pre_keys_head = ptr::null_mut();
+        sys::signal_protocol_key_helper_generate_pre_keys(
+            &mut pre_keys_head,
+            start,
+            count,
+            ctx.raw(),
+        )
+        .into_result()?;
+
+        Ok(PreKeyList::from_raw(pre_keys_head))
+    }
+}
+
+pub fn generate_signed_pre_key(
+    ctx: &Context,
+    identity_key_pair: &IdentityKeyPair,
+    id: u32,
+    timestamp: SystemTime,
+) -> Result<SessionSignedPreKey, Error> {
+    unsafe {
+        let mut raw = ptr::null_mut();
+        let unix_time = timestamp.duration_since(SystemTime::UNIX_EPOCH)?;
+
+        sys::signal_protocol_key_helper_generate_signed_pre_key(
+            &mut raw,
+            identity_key_pair.raw.as_const_ptr(),
+            id,
+            unix_time.as_secs(),
+            ctx.raw(),
+        )
+        .into_result()?;
+
+        if raw.is_null() {
+            Err(failure::err_msg("Unable to generate a signed pre key"))
+        } else {
+            Ok(SessionSignedPreKey {
+                raw: Raw::from_ptr(raw),
+            })
+        }
+    }
+}
+
+pub fn store_context<P, K, S, I>(
+    ctx: &Context,
+    pre_key_store: P,
+    signed_pre_key_store: K,
+    session_store: S,
+    identity_key_store: I,
+) -> Result<StoreContext, Error>
+where
+    P: PreKeyStore + 'static,
+    K: SignedPreKeyStore + 'static,
+    S: SessionStore + 'static,
+    I: IdentityKeyStore + 'static,
+{
+    unsafe {
+        let mut store_ctx = ptr::null_mut();
+        sys::signal_protocol_store_context_create(&mut store_ctx, ctx.raw())
+            .into_result()?;
+
+        let pre_key_store = pks::new_vtable(pre_key_store);
+        sys::signal_protocol_store_context_set_pre_key_store(
+            store_ctx,
+            &pre_key_store,
+        )
+        .into_result()?;
+
+        let signed_pre_key_store = spks::new_vtable(signed_pre_key_store);
+        sys::signal_protocol_store_context_set_signed_pre_key_store(
+            store_ctx,
+            &signed_pre_key_store,
+        )
+        .into_result()?;
+
+        let session_store = sess::new_vtable(session_store);
+        sys::signal_protocol_store_context_set_session_store(
+            store_ctx,
+            &session_store,
+        )
+        .into_result()?;
+
+        let identity_key_store = iks::new_vtable(identity_key_store);
+        sys::signal_protocol_store_context_set_identity_key_store(
+            store_ctx,
+            &identity_key_store,
+        )
+        .into_result()?;
+
+        Ok(StoreContext::new(store_ctx, &ctx.0))
+    }
+}
+
+pub fn create_hkdf(
+    ctx: &Context,
+    version: i32,
+) -> Result<HMACBasedKeyDerivationFunction, Error> {
+    HMACBasedKeyDerivationFunction::new(version, ctx)
+}
+
+pub fn session_builder(
+    ctx: &Context,
+    store_context: &StoreContext,
+    address: Address<'_>,
+) -> SessionBuilder {
+    SessionBuilder::new(ctx, store_context, address)
+}
+
 /// Global state and callbacks used by the library.
 pub struct Context(pub(crate) Rc<ContextInner>);
 
@@ -37,185 +214,6 @@ impl Context {
         ContextInner::new(crypto)
             .map(|c| Context(Rc::new(c)))
             .map_err(Error::from)
-    }
-
-    pub fn generate_identity_key_pair(&self) -> Result<IdentityKeyPair, Error> {
-        unsafe {
-            let mut key_pair = ptr::null_mut();
-            sys::signal_protocol_key_helper_generate_identity_key_pair(
-                &mut key_pair,
-                self.raw(),
-            )
-            .into_result()?;
-            Ok(IdentityKeyPair {
-                raw: Raw::from_ptr(key_pair),
-            })
-        }
-    }
-
-    pub fn generate_key_pair(&self) -> Result<KeyPair, Error> {
-        unsafe {
-            let mut key_pair = ptr::null_mut();
-            sys::curve_generate_key_pair(self.raw(), &mut key_pair)
-                .into_result()?;
-
-            Ok(KeyPair {
-                raw: Raw::from_ptr(key_pair),
-            })
-        }
-    }
-
-    pub fn calculate_signature(
-        &self,
-        private: &PrivateKey,
-        message: &[u8],
-    ) -> Result<Buffer, Error> {
-        unsafe {
-            let mut buffer = ptr::null_mut();
-            sys::curve_calculate_signature(
-                self.raw(),
-                &mut buffer,
-                private.raw.as_const_ptr(),
-                message.as_ptr(),
-                message.len(),
-            )
-            .into_result()?;
-
-            Ok(Buffer::from_raw(buffer))
-        }
-    }
-
-    pub fn generate_registration_id(
-        &self,
-        extended_range: i32,
-    ) -> Result<u32, Error> {
-        let mut id = 0;
-        unsafe {
-            sys::signal_protocol_key_helper_generate_registration_id(
-                &mut id,
-                extended_range,
-                self.raw(),
-            )
-            .into_result()?;
-        }
-
-        Ok(id)
-    }
-
-    pub fn generate_pre_keys(
-        &self,
-        start: u32,
-        count: u32,
-    ) -> Result<PreKeyList, Error> {
-        unsafe {
-            let mut pre_keys_head = ptr::null_mut();
-            sys::signal_protocol_key_helper_generate_pre_keys(
-                &mut pre_keys_head,
-                start,
-                count,
-                self.raw(),
-            )
-            .into_result()?;
-
-            Ok(PreKeyList::from_raw(pre_keys_head))
-        }
-    }
-
-    pub fn generate_signed_pre_key(
-        &self,
-        identity_key_pair: &IdentityKeyPair,
-        id: u32,
-        timestamp: SystemTime,
-    ) -> Result<SessionSignedPreKey, Error> {
-        unsafe {
-            let mut raw = ptr::null_mut();
-            let unix_time = timestamp.duration_since(SystemTime::UNIX_EPOCH)?;
-
-            sys::signal_protocol_key_helper_generate_signed_pre_key(
-                &mut raw,
-                identity_key_pair.raw.as_const_ptr(),
-                id,
-                unix_time.as_secs(),
-                self.raw(),
-            )
-            .into_result()?;
-
-            if raw.is_null() {
-                Err(failure::err_msg("Unable to generate a signed pre key"))
-            } else {
-                Ok(SessionSignedPreKey {
-                    raw: Raw::from_ptr(raw),
-                })
-            }
-        }
-    }
-
-    pub fn store_context<P, K, S, I>(
-        &self,
-        pre_key_store: P,
-        signed_pre_key_store: K,
-        session_store: S,
-        identity_key_store: I,
-    ) -> Result<StoreContext, Error>
-    where
-        P: PreKeyStore + 'static,
-        K: SignedPreKeyStore + 'static,
-        S: SessionStore + 'static,
-        I: IdentityKeyStore + 'static,
-    {
-        unsafe {
-            let mut store_ctx = ptr::null_mut();
-            sys::signal_protocol_store_context_create(
-                &mut store_ctx,
-                self.raw(),
-            )
-            .into_result()?;
-
-            let pre_key_store = pks::new_vtable(pre_key_store);
-            sys::signal_protocol_store_context_set_pre_key_store(
-                store_ctx,
-                &pre_key_store,
-            )
-            .into_result()?;
-
-            let signed_pre_key_store = spks::new_vtable(signed_pre_key_store);
-            sys::signal_protocol_store_context_set_signed_pre_key_store(
-                store_ctx,
-                &signed_pre_key_store,
-            )
-            .into_result()?;
-
-            let session_store = sess::new_vtable(session_store);
-            sys::signal_protocol_store_context_set_session_store(
-                store_ctx,
-                &session_store,
-            )
-            .into_result()?;
-
-            let identity_key_store = iks::new_vtable(identity_key_store);
-            sys::signal_protocol_store_context_set_identity_key_store(
-                store_ctx,
-                &identity_key_store,
-            )
-            .into_result()?;
-
-            Ok(StoreContext::new(store_ctx, &self.0))
-        }
-    }
-
-    pub fn create_hkdf(
-        &self,
-        version: i32,
-    ) -> Result<HMACBasedKeyDerivationFunction, Error> {
-        HMACBasedKeyDerivationFunction::new(version, self)
-    }
-
-    pub fn session_builder(
-        &self,
-        store_context: &StoreContext,
-        address: Address<'_>,
-    ) -> SessionBuilder {
-        SessionBuilder::new(self, store_context, address)
     }
 
     pub fn crypto(&self) -> &dyn Crypto { self.0.crypto.state() }

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -207,6 +207,9 @@ pub fn session_builder(
 }
 
 /// Global state and callbacks used by the library.
+///
+/// Most functions which require access to the global context (e.g. for crypto
+/// functions or locking) will accept a `&Context` as their first argument.
 pub struct Context(pub(crate) Rc<ContextInner>);
 
 impl Context {

--- a/libsignal-protocol/src/crypto/mod.rs
+++ b/libsignal-protocol/src/crypto/mod.rs
@@ -1,3 +1,5 @@
+//! Underlying cryptographic routines.
+
 #[cfg(feature = "crypto-native")]
 mod native;
 #[cfg(feature = "crypto-native")]
@@ -22,6 +24,7 @@ use crate::{
     errors::{InternalError, IntoInternalErrorCode},
 };
 
+/// The error returned from a failed conversion to [`SignalCipherType`].
 #[derive(Debug, Clone)]
 pub struct SignalCipherTypeError(i32);
 

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -100,11 +100,11 @@ impl InternalError {
     }
 }
 
-pub(crate) trait FromInternalErrorCode: Sized {
+pub trait FromInternalErrorCode: Sized {
     fn into_result(self) -> Result<(), InternalError>;
 }
 
-pub(crate) trait IntoInternalErrorCode: Sized {
+pub trait IntoInternalErrorCode: Sized {
     fn into_code(self) -> i32;
 }
 

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -55,9 +55,8 @@ extern crate libsignal_protocol_sys as sys;
 pub use crate::{
     address::Address,
     buffer::Buffer,
-    context::Context,
-    crypto::{CipherMode, Crypto, SignalCipherType, SignalCipherTypeError},
-    errors::InternalError,
+    context::*,
+    errors::{FromInternalErrorCode, InternalError, IntoInternalErrorCode},
     hkdf::HMACBasedKeyDerivationFunction,
     identity_key_store::IdentityKeyStore,
     pre_key_bundle::{PreKeyBundle, PreKeyBundleBuilder},

--- a/libsignal-protocol/tests/helpers/mod.rs
+++ b/libsignal-protocol/tests/helpers/mod.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
 
 use libsignal_protocol::{
-    crypto::{Crypto, Sha256Hmac, Sha512Digest},
+    crypto::{Crypto, Sha256Hmac, Sha512Digest, SignalCipherType},
     Address, Buffer, IdentityKeyStore, InternalError, PreKeyStore,
-    SerializedSession, SessionStore, SignalCipherType, SignedPreKeyStore,
+    SerializedSession, SessionStore, SignedPreKeyStore,
 };
 use std::{
     cell::{Cell, RefCell},


### PR DESCRIPTION
At the moment, most functions which require access to the global `libsignal-protocol` context are implemented as methods on the `Context` type. 

It's probably better to rewrite these as free functions, that way the crate's core functionality is more visible (it's viewable at the top level instead of digging into the `Context` docs). It also helps answer the question of "which type do I attach this method to?" when you need to access the context and one or two stores (e.g. the `session_builder` function or `store_context` "constructors").

This is a big change from an ergonomics perspective. @shekohex, what are your thoughts on this?