### PR TITLE
Added a script which will run valgrind on all binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,17 @@ language: rust
 sudo: false
 cache: cargo
 
+addons:
+  apt:
+    update: true
+    packages:
+      - valgrind
+
 script: 
   - cargo build --all --verbose
   - cargo test --all --verbose
   - cargo doc --all --verbose
+  - python3 ./scripts/valgrind.py
 
 before_deploy:
   - cargo doc --all --verbose

--- a/scripts/valgrind.py
+++ b/scripts/valgrind.py
@@ -1,0 +1,76 @@
+#!/bin/env python3
+
+import subprocess
+import json
+from pprint import pprint
+from functools import partial
+from os import path
+import os
+from pathlib import Path
+
+ignored = ["sessions"]
+ignored = []
+
+PROJECT_ROOT = Path(__file__).parent.parent
+CARGO_TOML = PROJECT_ROOT.joinpath("libsignal-protocol", "Cargo.toml")
+
+
+def examples(target_dir: Path):
+    """
+    Use `cargo manifest` to find the executable that corresponds to each of
+    the library's examples.
+    """
+    manifest = get_manifest()
+
+    for pkg in manifest["packages"]:
+        if pkg["name"] == "libsignal-protocol":
+            targets = pkg["targets"]
+
+            for target in targets:
+                if "example" in target["kind"] and target["name"] not in ignored:
+                    yield target_dir.joinpath("debug", "examples", target["name"])
+
+
+def get_manifest():
+    args = ["cargo", "metadata", "--no-deps", "--format-version=1",
+            "--manifest-path", str(CARGO_TOML)]
+
+    output = subprocess.run(args, check=True, stdout=subprocess.PIPE)
+    return json.loads(output.stdout.decode("utf-8"))
+
+
+def integration_tests():
+    """
+    Get the executable corresponding to the crate's tests (excluding doc-tests).
+    """
+    args = ["cargo", "test", "--tests", "--no-run", "--message-format=json",
+            "--manifest-path", str(CARGO_TOML)]
+    output = subprocess.run(args, check=True, stdout=subprocess.PIPE)
+    stdout = output.stdout.decode("utf-8")
+
+    for line in stdout.splitlines():
+        line = json.loads(line)
+        if line["reason"] == "compiler-artifact" and "test" in line["target"]["kind"]:
+            yield line["executable"]
+
+
+def run_valgrind(original_cmd):
+    args = ["valgrind", "--leak-check=full", "--trace-children=yes",
+            "--show-leak-kinds=all", "--error-exitcode=1", *original_cmd]
+
+    env = os.environ.copy()
+    env["RUST_BACKTRACE"] = "full"
+    subprocess.run(args, check=True, env=env)
+
+
+def main():
+    binaries = []
+    binaries.extend(examples(Path("target")))
+    binaries.extend(integration_tests())
+
+    for binary in binaries:
+        run_valgrind([binary])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/valgrind.py
+++ b/scripts/valgrind.py
@@ -56,7 +56,8 @@ def integration_tests():
 
 def run_valgrind(original_cmd):
     args = ["valgrind", "--leak-check=full", "--trace-children=yes",
-            "--show-leak-kinds=all", "--error-exitcode=1", *original_cmd]
+            "--show-leak-kinds=all", "--error-exitcode=1"]
+    args.extend(original_cmd)
 
     env = os.environ.copy()
     env["RUST_BACKTRACE"] = "full"

--- a/scripts/valgrind.py
+++ b/scripts/valgrind.py
@@ -9,7 +9,6 @@ import os
 from pathlib import Path
 
 ignored = ["sessions"]
-ignored = []
 
 PROJECT_ROOT = Path(__file__).parent.parent
 CARGO_TOML = PROJECT_ROOT.joinpath("libsignal-protocol", "Cargo.toml")
@@ -35,8 +34,8 @@ def get_manifest():
     args = ["cargo", "metadata", "--no-deps", "--format-version=1",
             "--manifest-path", str(CARGO_TOML)]
 
-    output = subprocess.run(args, check=True, stdout=subprocess.PIPE)
-    return json.loads(output.stdout.decode("utf-8"))
+    output = subprocess.check_output(args)
+    return json.loads(output.decode("utf-8"))
 
 
 def integration_tests():
@@ -45,8 +44,8 @@ def integration_tests():
     """
     args = ["cargo", "test", "--tests", "--no-run", "--message-format=json",
             "--manifest-path", str(CARGO_TOML)]
-    output = subprocess.run(args, check=True, stdout=subprocess.PIPE)
-    stdout = output.stdout.decode("utf-8")
+    output = subprocess.check_output(args)
+    stdout = output.decode("utf-8")
 
     for line in stdout.splitlines():
         line = json.loads(line)
@@ -61,7 +60,7 @@ def run_valgrind(original_cmd):
 
     env = os.environ.copy()
     env["RUST_BACKTRACE"] = "full"
-    subprocess.run(args, check=True, env=env)
+    subprocess.check_call(args, env=env)
 
 
 def main():
@@ -70,7 +69,7 @@ def main():
     binaries.extend(integration_tests())
 
     for binary in binaries:
-        run_valgrind([binary])
+        run_valgrind([str(binary)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a PR to run valgrind over all examples and test binaries as part of the CI process. If we introduce any memory leaks or use pointers incorrectly, valgrind should complain.