### PR TITLE
Add `miri` to the ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ matrix:
       script:
         - cargo fmt --all -- --check
         - cargo clippy -- -D clippy::all
+    - rust: nightly
+        before_script:
+          - rustup component add miri
+          - cargo miri setup
+        script:
+          - cargo miri test -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
 
 deploy:
   provider: pages


### PR DESCRIPTION
This adds [miri](https://github.com/rust-lang/miri) as a component from rust up, and run all tests from miri.

Signed-off-by: Shady Khalifa <shekohex@gmail.com>