### PR TITLE
Make travis happy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,12 @@ addons:
     packages:
       - valgrind
 
-before_script:
-  - export PATH=$HOME/.cargo/bin:$PATH
-  - cargo install --debug bindgen
-
 script: 
   - cargo build --all --verbose
   - cargo test --all --verbose
   - cargo doc --all --verbose
     # Check that the (non-blacklisted) examples and tests don't have memory bugs
   - python3 ./scripts/valgrind.py
-    # Make sure our generated bindings are up to date
-  - ./scripts/generate_bindings.sh
-  - git diff --exit-code -- libsignal-protocol-sys/bindings.rs || (echo "Bindings are outdated" && exit 1)
 
 before_deploy:
   - cargo doc --all --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,6 @@ matrix:
       script:
         - cargo fmt --all -- --check
         - cargo clippy -- -D clippy::all
-    - rust: nightly
-      before_script:
-        - rustup component add miri
-        - cargo miri setup
-      script:
-        - cargo miri test -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,11 @@ script:
   - cargo build --all --verbose
   - cargo test --all --verbose
   - cargo doc --all --verbose
+    # Check that the (non-blacklisted) examples and tests don't have memory bugs
   - python3 ./scripts/valgrind.py
-  - git diff --exit-code -- libsignal-protocol-sys/bindings.rs || echo "Bindings are outdated" && exit 1
+    # Make sure our generated bindings are up to date
+  - ./scripts/generate_bindings.sh
+  - git diff --exit-code -- libsignal-protocol-sys/bindings.rs || (echo "Bindings are outdated" && exit 1)
 
 before_deploy:
   - cargo doc --all --verbose

--- a/scripts/valgrind.py
+++ b/scripts/valgrind.py
@@ -49,7 +49,7 @@ def integration_tests():
 
     for line in stdout.splitlines():
         line = json.loads(line)
-        if line["reason"] == "compiler-artifact" and "test" in line["target"]["kind"]:
+        if line["reason"] == "compiler-artifact" and "test" in line["target"]["kind"] and line.get("name") not in ignored:
             yield line["executable"]
 
 

--- a/scripts/valgrind.py
+++ b/scripts/valgrind.py
@@ -2,7 +2,6 @@
 
 import subprocess
 import json
-from pprint import pprint
 from functools import partial
 from os import path
 import os
@@ -49,7 +48,14 @@ def integration_tests():
 
     for line in stdout.splitlines():
         line = json.loads(line)
-        if line["reason"] == "compiler-artifact" and "test" in line["target"]["kind"] and line.get("name") not in ignored:
+        target = line.get("target")
+        if not target:
+            continue
+
+        is_test = "test" in target["kind"]
+        not_ignored = target["name"] not in ignored
+
+        if line["reason"] == "compiler-artifact" and is_test and not_ignored:
             yield line["executable"]
 
 

--- a/scripts/valgrind.py
+++ b/scripts/valgrind.py
@@ -8,7 +8,7 @@ from os import path
 import os
 from pathlib import Path
 
-ignored = ["sessions"]
+ignored = ["sessions", "libsignal-protocol-c-tests"]
 
 PROJECT_ROOT = Path(__file__).parent.parent
 CARGO_TOML = PROJECT_ROOT.joinpath("libsignal-protocol", "Cargo.toml")


### PR DESCRIPTION
It looks like this we'll need to merge both this PR and #28 at the same time to make travis happy again. I'll close that other branch in favour of this one.

---

# Original PR: Some integration tests leak memory

It looks like Rust's test harness leaks memory somewhere. Strangely, this gives different results when I run it on my computer versus travis.

On my laptop it says there are two chunks of reachable memory at the end of the program (e.g. statics which lazily allocate heap memory). In this case, both chunks of memory seem to come from the `backtrace` crate.

<details>
<summary>valgrind output on laptop</summary>

```
==15595== Memcheck, a memory error detector
==15595== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==15595== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==15595== Command: /home/michael/Documents/libsignal-protocol-rs/target/debug/libsignal_protocol_c_tests-56cc0a8927f86815
==15595== 

running 8 tests
test test_hkdf_vector_v2 ... ignored
test test_curve25519_large_signatures ... ok
test test_curve25519_generate_public ... ok
test test_generate_identity_key_pair ... ok
test test_basic_pre_key_v2 ... ok
test test_generate_pre_keys ... ok
test test_curve25519_signature ... ok
test test_generate_signed_pre_key ... ok

test result: ok. 7 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out

==15595== 
==15595== HEAP SUMMARY:
==15595==     in use at exit: 56 bytes in 2 blocks
==15595==   total heap usage: 1,257 allocs, 1,255 frees, 6,525,537 bytes allocated
==15595== 
==15595== 16 bytes in 1 blocks are still reachable in loss record 1 of 2
==15595==    at 0x483874F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15595==    by 0x1D310B: alloc::alloc::alloc (alloc.rs:75)
==15595==    by 0x1D3079: alloc::alloc::exchange_malloc (alloc.rs:185)
==15595==    by 0x1DE52D: new<std::sync::mutex::Mutex<()>> (boxed.rs:113)
==15595==    by 0x1DE52D: backtrace::lock::lock::{{closure}} (lib.rs:175)
==15595==    by 0x1DA1ED: std::sync::once::Once::call_once::{{closure}} (once.rs:220)
==15595==    by 0x216705: std::sync::once::Once::call_inner (once.rs:387)
==15595==    by 0x1DA172: std::sync::once::Once::call_once (once.rs:220)
==15595==    by 0x1DE464: backtrace::lock::lock (lib.rs:174)
==15595==    by 0x1CD27B: trace<closure> (mod.rs:46)
==15595==    by 0x1CD27B: backtrace::capture::Backtrace::create (capture.rs:105)
==15595==    by 0x1CD1A3: backtrace::capture::Backtrace::new_unresolved (capture.rs:96)
==15595==    by 0x1CA892: failure::backtrace::internal::InternalBacktrace::new (internal.rs:44)
==15595==    by 0x1CA63D: failure::backtrace::Backtrace::new (mod.rs:111)
==15595== 
==15595== 40 bytes in 1 blocks are still reachable in loss record 2 of 2
==15595==    at 0x483874F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15595==    by 0x1D310B: alloc::alloc::alloc (alloc.rs:75)
==15595==    by 0x1D3079: alloc::alloc::exchange_malloc (alloc.rs:185)
==15595==    by 0x1D2BFC: std::sync::mutex::Mutex<T>::new (mutex.rs:170)
==15595==    by 0x1DE51E: backtrace::lock::lock::{{closure}} (lib.rs:175)
==15595==    by 0x1DA1ED: std::sync::once::Once::call_once::{{closure}} (once.rs:220)
==15595==    by 0x216705: std::sync::once::Once::call_inner (once.rs:387)
==15595==    by 0x1DA172: std::sync::once::Once::call_once (once.rs:220)
==15595==    by 0x1DE464: backtrace::lock::lock (lib.rs:174)
==15595==    by 0x1CD27B: trace<closure> (mod.rs:46)
==15595==    by 0x1CD27B: backtrace::capture::Backtrace::create (capture.rs:105)
==15595==    by 0x1CD1A3: backtrace::capture::Backtrace::new_unresolved (capture.rs:96)
==15595==    by 0x1CA892: failure::backtrace::internal::InternalBacktrace::new (internal.rs:44)
==15595== 
==15595== LEAK SUMMARY:
==15595==    definitely lost: 0 bytes in 0 blocks
==15595==    indirectly lost: 0 bytes in 0 blocks
==15595==      possibly lost: 0 bytes in 0 blocks
==15595==    still reachable: 56 bytes in 2 blocks
==15595==         suppressed: 0 bytes in 0 blocks
==15595== 
==15595== For counts of detected and suppressed errors, rerun with: -v
==15595== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
</details>

Whereas running it [on travis](https://travis-ci.com/Michael-F-Bryan/libsignal-protocol-rs/jobs/201812477) shows the same leaked `backtrace` memory and something to do with threads (TLS?).

<details>
<summary>Valgrind output on Travis</summary>

```
==9683== Memcheck, a memory error detector
==9683== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==9683== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==9683== Command: /home/travis/build/Michael-F-Bryan/libsignal-protocol-rs/target/debug/libsignal_protocol_c_tests-eeae93d0d004a615
==9683== 
running 8 tests
test test_basic_pre_key_v2 ... ok
test test_curve25519_generate_public ... ok
test test_curve25519_large_signatures ... ok
test test_curve25519_signature ... ok
test test_generate_pre_keys ... ok
test test_generate_identity_key_pair ... ok
test test_hkdf_vector_v2 ... ignored
test test_generate_signed_pre_key ... ok
test result: ok. 7 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
==9683== 
==9683== HEAP SUMMARY:
==9683==     in use at exit: 664 bytes in 5 blocks
==9683==   total heap usage: 1,622 allocs, 1,617 frees, 6,561,405 bytes allocated
==9683== 
==9683== 16 bytes in 1 blocks are still reachable in loss record 1 of 4
==9683==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9683==    by 0x1F51AB: alloc::alloc::alloc::h263054e5d42b36f9 (alloc.rs:75)
==9683==    by 0x1F5119: alloc::alloc::exchange_malloc::h385bcdf7f4106e62 (alloc.rs:185)
==9683==    by 0x1FF22D: new<std::sync::mutex::Mutex<()>> (boxed.rs:111)
==9683==    by 0x1FF22D: backtrace::lock::lock::_$u7b$$u7b$closure$u7d$$u7d$::hfc2586ff41831781 (lib.rs:175)
==9683==    by 0x1F7B2D: std::sync::once::Once::call_once::_$u7b$$u7b$closure$u7d$$u7d$::h26b2f33482030f5e (in /home/travis/build/Michael-F-Bryan/libsignal-protocol-rs/target/debug/libsignal_protocol_c_tests-eeae93d0d004a615)
==9683==    by 0x2367E5: std::sync::once::Once::call_inner::h99969eb55f2f5e7e (once.rs:387)
==9683==    by 0x1F79AF: std::sync::once::Once::call_once::h923cf37120372725 (once.rs:220)
==9683==    by 0x1FF168: backtrace::lock::lock::h35b741808eb558c3 (lib.rs:174)
==9683==    by 0x1EFFCB: trace<closure> (mod.rs:46)
==9683==    by 0x1EFFCB: backtrace::capture::Backtrace::create::hd5686c926a56b3ca (capture.rs:105)
==9683==    by 0x1EFEF3: backtrace::capture::Backtrace::new_unresolved::h2fc13a6dac99c6ea (capture.rs:96)
==9683==    by 0x1EE9A2: failure::backtrace::internal::InternalBacktrace::new::hfbbe86e2f69f0d53 (internal.rs:44)
==9683==    by 0x1EDDFD: failure::backtrace::Backtrace::new::h29cb2896887f4743 (mod.rs:111)
==9683== 
==9683== 32 bytes in 1 blocks are still reachable in loss record 2 of 4
==9683==    at 0x4C2CC70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9683==    by 0x4E3868F: _dlerror_run (dlerror.c:141)
==9683==    by 0x4E38197: dlsym (dlsym.c:70)
==9683==    by 0x23D176: fetch (weak.rs:67)
==9683==    by 0x23D176: get<unsafe extern "C" fn(*const libc::unix::notbsd::linux::other::b64::x86_64::pthread_attr_t) -> usize> (weak.rs:52)
==9683==    by 0x23D176: min_stack_size (thread.rs:411)
==9683==    by 0x23D176: std::sys::unix::thread::Thread::new::hdb6294912acb6aba (thread.rs:50)
==9683==    by 0x188622: spawn_unchecked<closure,()> (mod.rs:488)
==9683==    by 0x188622: spawn<closure,()> (mod.rs:382)
==9683==    by 0x188622: test::run_test::run_test_inner::hf1a650ca7ed0bfda (lib.rs:1472)
==9683==    by 0x186A8F: test::run_test::h721f02a8a2f9fda1 (lib.rs:1493)
==9683==    by 0x1803B1: run_tests<closure> (lib.rs:1167)
==9683==    by 0x1803B1: test::run_tests_console::hc07da043670a9514 (lib.rs:961)
==9683==    by 0x177187: test::test_main::h01b89c7f40330ffb (lib.rs:293)
==9683==    by 0x1779B3: test::test_main_static::h872c35a735f78a49 (lib.rs:327)
==9683==    by 0x15E3A5: libsignal_protocol_c_tests::main::h256e89189581b4ca (in /home/travis/build/Michael-F-Bryan/libsignal-protocol-rs/target/debug/libsignal_protocol_c_tests-eeae93d0d004a615)
==9683==    by 0x15948F: std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::h91dca1c2f4da1ce3 (in /home/travis/build/Michael-F-Bryan/libsignal-protocol-rs/target/debug/libsignal_protocol_c_tests-eeae93d0d004a615)
==9683==    by 0x23A7A2: {{closure}} (rt.rs:49)
==9683==    by 0x23A7A2: std::panicking::try::do_call::hd5665e82951fbbd9 (panicking.rs:297)
==9683== 
==9683== 40 bytes in 1 blocks are still reachable in loss record 3 of 4
==9683==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9683==    by 0x1F51AB: alloc::alloc::alloc::h263054e5d42b36f9 (alloc.rs:75)
==9683==    by 0x1F5119: alloc::alloc::exchange_malloc::h385bcdf7f4106e62 (alloc.rs:185)
==9683==    by 0x1F542C: _$LT$std..sync..mutex..Mutex$LT$T$GT$$GT$::new::h0a55c629293b8f04 (mutex.rs:170)
==9683==    by 0x1FF21E: backtrace::lock::lock::_$u7b$$u7b$closure$u7d$$u7d$::hfc2586ff41831781 (lib.rs:175)
==9683==    by 0x1F7B2D: std::sync::once::Once::call_once::_$u7b$$u7b$closure$u7d$$u7d$::h26b2f33482030f5e (in /home/travis/build/Michael-F-Bryan/libsignal-protocol-rs/target/debug/libsignal_protocol_c_tests-eeae93d0d004a615)
==9683==    by 0x2367E5: std::sync::once::Once::call_inner::h99969eb55f2f5e7e (once.rs:387)
==9683==    by 0x1F79AF: std::sync::once::Once::call_once::h923cf37120372725 (once.rs:220)
==9683==    by 0x1FF168: backtrace::lock::lock::h35b741808eb558c3 (lib.rs:174)
==9683==    by 0x1EFFCB: trace<closure> (mod.rs:46)
==9683==    by 0x1EFFCB: backtrace::capture::Backtrace::create::hd5686c926a56b3ca (capture.rs:105)
==9683==    by 0x1EFEF3: backtrace::capture::Backtrace::new_unresolved::h2fc13a6dac99c6ea (capture.rs:96)
==9683==    by 0x1EE9A2: failure::backtrace::internal::InternalBacktrace::new::hfbbe86e2f69f0d53 (internal.rs:44)
==9683== 
==9683== 576 bytes in 2 blocks are possibly lost in loss record 4 of 4
==9683==    at 0x4C2CC70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9683==    by 0x4012EE4: allocate_dtv (dl-tls.c:296)
==9683==    by 0x4012EE4: _dl_allocate_tls (dl-tls.c:460)
==9683==    by 0x524BD92: allocate_stack (allocatestack.c:589)
==9683==    by 0x524BD92: pthread_create@@GLIBC_2.2.5 (pthread_create.c:500)
==9683==    by 0x23D221: std::sys::unix::thread::Thread::new::hdb6294912acb6aba (thread.rs:69)
==9683==    by 0x188622: spawn_unchecked<closure,()> (mod.rs:488)
==9683==    by 0x188622: spawn<closure,()> (mod.rs:382)
==9683==    by 0x188622: test::run_test::run_test_inner::hf1a650ca7ed0bfda (lib.rs:1472)
==9683==    by 0x186A8F: test::run_test::h721f02a8a2f9fda1 (lib.rs:1493)
==9683==    by 0x1803B1: run_tests<closure> (lib.rs:1167)
==9683==    by 0x1803B1: test::run_tests_console::hc07da043670a9514 (lib.rs:961)
==9683==    by 0x177187: test::test_main::h01b89c7f40330ffb (lib.rs:293)
==9683==    by 0x1779B3: test::test_main_static::h872c35a735f78a49 (lib.rs:327)
==9683==    by 0x15E3A5: libsignal_protocol_c_tests::main::h256e89189581b4ca (in /home/travis/build/Michael-F-Bryan/libsignal-protocol-rs/target/debug/libsignal_protocol_c_tests-eeae93d0d004a615)
==9683==    by 0x15948F: std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::h91dca1c2f4da1ce3 (in /home/travis/build/Michael-F-Bryan/libsignal-protocol-rs/target/debug/libsignal_protocol_c_tests-eeae93d0d004a615)
==9683==    by 0x23A7A2: {{closure}} (rt.rs:49)
==9683==    by 0x23A7A2: std::panicking::try::do_call::hd5665e82951fbbd9 (panicking.rs:297)
==9683== 
==9683== LEAK SUMMARY:
==9683==    definitely lost: 0 bytes in 0 blocks
==9683==    indirectly lost: 0 bytes in 0 blocks
==9683==      possibly lost: 576 bytes in 2 blocks
==9683==    still reachable: 88 bytes in 3 blocks
==9683==         suppressed: 0 bytes in 0 blocks
==9683== 
==9683== For counts of detected and suppressed errors, rerun with: -v
==9683== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

</details>

Either way, I'll need to find a way to ignore leaks from outside the crate, or skip running valgrind over the integration tests altogether...