### PR TITLE
[WIP] Fully In Memory Store under feature `in-memory-store`

### DIFF
--- a/libsignal-protocol/Cargo.toml
+++ b/libsignal-protocol/Cargo.toml
@@ -18,6 +18,7 @@ sha2 = { version = "0.8.0", optional = true }
 hmac = { version = "0.7.0", optional = true }
 
 [features]
-default = ["crypto-native"]
+default = ["crypto-native", "in-memory-store"]
 crypto-native = ["sha2", "hmac"] # TODO(shekohex): find a way to add `aes`.
 crypto-openssl = ["openssl"]
+in-memory-store = []

--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -45,18 +45,21 @@
 
 extern crate libsignal_protocol as sig;
 
-#[path = "../tests/helpers/mod.rs"]
-mod helpers;
+use std::time::SystemTime;
+
+use failure::{Error, ResultExt};
+
+use sig::{
+    Address, Context, PreKeyBundle, Serializable, SessionBuilder, SessionCipher,
+};
 
 use self::helpers::{
     BasicIdentityKeyStore, BasicPreKeyStore, BasicSessionStore,
     BasicSignedPreKeyStore,
 };
-use failure::{Error, ResultExt};
-use sig::{
-    Address, Context, PreKeyBundle, Serializable, SessionBuilder, SessionCipher,
-};
-use std::time::SystemTime;
+
+#[path = "../tests/helpers/mod.rs"]
+mod helpers;
 
 fn main() -> Result<(), Error> {
     let ctx = Context::default();
@@ -65,7 +68,7 @@ fn main() -> Result<(), Error> {
     let bob_address = Address::new("+14159998888", 1);
     let bob_identity_keys = sig::generate_identity_key_pair(&ctx)
         .context("Unable to generate bob's keys")?;
-    let bob_public_identity_key = bob_identity_keys.public()?;
+    let bob_public_identity_key = bob_identity_keys.public();
     let bob_pre_keys: Vec<_> = sig::generate_pre_keys(&ctx, 0, 10)
         .context("Unable to generate bob's pre-keys")?
         .iter()

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -1,7 +1,3 @@
-use failure::Error;
-
-use lock_api::RawMutex as _;
-use parking_lot::RawMutex;
 use std::{
     ffi::c_void,
     fmt::{self, Debug, Formatter},
@@ -10,6 +6,10 @@ use std::{
     rc::Rc,
     time::SystemTime,
 };
+
+use failure::Error;
+use lock_api::RawMutex as _;
+use parking_lot::RawMutex;
 
 #[cfg(feature = "crypto-native")]
 use crate::crypto::DefaultCrypto;
@@ -152,7 +152,7 @@ where
     P: PreKeyStore + 'static,
     K: SignedPreKeyStore + 'static,
     S: SessionStore + 'static,
-    I: IdentityKeyStore + 'static,
+    I: IdentityKeyStore<'static> + 'static,
 {
     unsafe {
         let mut store_ctx = ptr::null_mut();

--- a/libsignal-protocol/src/keys/identity_key_pair.rs
+++ b/libsignal-protocol/src/keys/identity_key_pair.rs
@@ -58,11 +58,4 @@ impl IdentityKeyPair {
     }
 }
 
-impl Drop for IdentityKeyPair {
-    fn drop(&mut self) {
-        unsafe {
-            sys::ratchet_identity_key_pair_destroy(self.raw.as_ptr() as _)
-        }
-    }
-}
 impl_serializable!(IdentityKeyPair, ratchet_identity_key_pair_serialize, foo);

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -52,19 +52,20 @@
 
 extern crate libsignal_protocol_sys as sys;
 
+use std::io::Write;
+
+use failure::Error;
+
 pub use crate::{
     address::Address,
     buffer::Buffer,
     context::*,
     errors::{FromInternalErrorCode, InternalError, IntoInternalErrorCode},
     hkdf::HMACBasedKeyDerivationFunction,
-    identity_key_store::IdentityKeyStore,
     pre_key_bundle::{PreKeyBundle, PreKeyBundleBuilder},
-    pre_key_store::PreKeyStore,
     session_builder::SessionBuilder,
     session_cipher::SessionCipher,
-    session_store::{SerializedSession, SessionStore},
-    signed_pre_key_store::SignedPreKeyStore,
+    store::*,
     store_context::StoreContext,
 };
 
@@ -77,20 +78,14 @@ mod context;
 pub mod crypto;
 mod errors;
 mod hkdf;
-mod identity_key_store;
 pub mod keys;
 mod messages;
 mod pre_key_bundle;
-mod pre_key_store;
 mod raw_ptr;
 mod session_builder;
 mod session_cipher;
-mod session_store;
-mod signed_pre_key_store;
+mod store;
 mod store_context;
-
-use failure::Error;
-use std::io::Write;
 
 pub trait Serializable {
     fn serialize(&self) -> Result<Buffer, Error>;

--- a/libsignal-protocol/src/store/mod.rs
+++ b/libsignal-protocol/src/store/mod.rs
@@ -1,0 +1,84 @@
+pub(crate) mod identity_key_store;
+pub(crate) mod pre_key_store;
+pub(crate) mod session_store;
+pub(crate) mod signed_pre_key_store;
+
+pub use self::{
+    identity_key_store::IdentityKeyStore,
+    pre_key_store::PreKeyStore,
+    session_store::{SerializedSession, SessionStore},
+    signed_pre_key_store::SignedPreKeyStore,
+};
+
+#[cfg(feature = "in-memory-store")]
+pub mod in_memory_store {
+    use crate::{keys::IdentityKeyPair, Address, InternalError};
+    use std::{borrow::ToOwned, collections::HashMap, sync::Mutex};
+
+    pub struct InMemoryIdentityKeyStore<'a> {
+        trusted_keys: Mutex<HashMap<Address<'a>, Vec<u8>>>,
+        local_registration_id: u32,
+        identity_key_pair: IdentityKeyPair,
+    }
+
+    impl<'a> InMemoryIdentityKeyStore<'a> {
+        pub fn new(
+            identity_key_pair: IdentityKeyPair,
+            local_registration_id: u32,
+        ) -> Self {
+            Self {
+                trusted_keys: Mutex::new(HashMap::new()),
+                local_registration_id,
+                identity_key_pair,
+            }
+        }
+    }
+
+    impl<'a> super::IdentityKeyStore<'a> for InMemoryIdentityKeyStore<'a> {
+        fn identity_key_pair(&self) -> Result<IdentityKeyPair, InternalError> {
+            Ok(self.identity_key_pair.clone())
+        }
+
+        fn local_registration_id(&self) -> Result<u32, InternalError> {
+            Ok(self.local_registration_id)
+        }
+
+        fn save_identity(
+            &self,
+            address: Address<'a>,
+            identity_key: &[u8],
+        ) -> Result<bool, InternalError> {
+            let mut guard = self
+                .trusted_keys
+                .lock()
+                .map_err(|_| InternalError::Unknown)?;
+            let existing = guard.contains_key(&address);
+            if !existing {
+                guard.insert(address, identity_key.to_owned());
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+
+        fn is_trusted_identity(
+            &self,
+            address: Address,
+            identity_key: &[u8],
+        ) -> Result<bool, InternalError> {
+            let guard = self
+                .trusted_keys
+                .lock()
+                .map_err(|_| InternalError::Unknown)?;
+            let identity = guard.get(&address);
+            let is_trusted = identity.is_none() || {
+                if let Some(data) = identity {
+                    data.as_slice() == identity_key
+                } else {
+                    false
+                }
+            };
+            Ok(is_trusted)
+        }
+    }
+}

--- a/libsignal-protocol/src/store/pre_key_store.rs
+++ b/libsignal-protocol/src/store/pre_key_store.rs
@@ -1,8 +1,9 @@
-use crate::{buffer::Buffer, errors::InternalError};
 use std::{
     io::{self, Write},
     os::raw::{c_int, c_void},
 };
+
+use crate::{buffer::Buffer, errors::InternalError};
 
 pub trait PreKeyStore {
     fn load(&self, id: u32, writer: &mut dyn Write) -> io::Result<()>;

--- a/libsignal-protocol/src/store/session_store.rs
+++ b/libsignal-protocol/src/store/session_store.rs
@@ -1,5 +1,6 @@
-use crate::{errors::InternalError, Address, Buffer};
 use std::os::raw::{c_char, c_int, c_void};
+
+use crate::{errors::InternalError, Address, Buffer};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SerializedSession {

--- a/libsignal-protocol/src/store/signed_pre_key_store.rs
+++ b/libsignal-protocol/src/store/signed_pre_key_store.rs
@@ -1,8 +1,9 @@
-use crate::{buffer::Buffer, errors::InternalError};
 use std::{
     io::{self, Write},
     os::raw::{c_int, c_void},
 };
+
+use crate::{buffer::Buffer, errors::InternalError};
 
 pub trait SignedPreKeyStore {
     fn load(&self, id: u32, writer: &mut dyn Write) -> io::Result<()>;

--- a/libsignal-protocol/tests/helpers/mod.rs
+++ b/libsignal-protocol/tests/helpers/mod.rs
@@ -81,7 +81,7 @@ pub fn fake_random_generator() -> impl Fn(&mut [u8]) -> Result<(), InternalError
 {
     let test_next_random = Cell::new(0);
 
-    move |mut data| {
+    move |data| {
         for i in 0..data.len() {
             data[i] = test_next_random.get();
             test_next_random.set(test_next_random.get().wrapping_add(1));

--- a/libsignal-protocol/tests/helpers/mod.rs
+++ b/libsignal-protocol/tests/helpers/mod.rs
@@ -1,14 +1,16 @@
 #![allow(dead_code)]
 
-use libsignal_protocol::{
-    crypto::{Crypto, Sha256Hmac, Sha512Digest, SignalCipherType},
-    Address, Buffer, IdentityKeyStore, InternalError, PreKeyStore,
-    SerializedSession, SessionStore, SignedPreKeyStore,
-};
 use std::{
     cell::{Cell, RefCell},
     collections::HashMap,
     io::{self, Write},
+};
+
+use libsignal_protocol::{
+    crypto::{Crypto, Sha256Hmac, Sha512Digest, SignalCipherType},
+    keys::IdentityKeyPair,
+    Address, IdentityKeyStore, InternalError, PreKeyStore, SerializedSession,
+    SessionStore, SignedPreKeyStore,
 };
 
 pub(crate) struct MockCrypto<C> {
@@ -79,7 +81,7 @@ pub fn fake_random_generator() -> impl Fn(&mut [u8]) -> Result<(), InternalError
 {
     let test_next_random = Cell::new(0);
 
-    move |data| {
+    move |mut data| {
         for i in 0..data.len() {
             data[i] = test_next_random.get();
             test_next_random.set(test_next_random.get().wrapping_add(1));
@@ -173,12 +175,20 @@ impl<'a> From<Address<'a>> for OwnedAddress {
     }
 }
 
-impl IdentityKeyStore for BasicIdentityKeyStore {
+impl IdentityKeyStore<'_> for BasicIdentityKeyStore {
+    fn identity_key_pair(&self) -> Result<IdentityKeyPair, InternalError> {
+        unimplemented!()
+    }
+
     fn local_registration_id(&self) -> Result<u32, InternalError> {
         Ok(self.registration_id.get())
     }
 
-    fn identity_key_pair(&self) -> Result<(Buffer, Buffer), InternalError> {
+    fn save_identity(
+        &self,
+        address: Address,
+        identity_key: &[u8],
+    ) -> Result<bool, InternalError> {
         unimplemented!()
     }
 

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -1,16 +1,19 @@
 extern crate libsignal_protocol as sig;
-mod helpers;
 
-use crate::helpers::{
-    fake_random_generator, BasicIdentityKeyStore, BasicPreKeyStore,
-    BasicSessionStore, BasicSignedPreKeyStore, MockCrypto,
-};
+use std::time::{Duration, SystemTime};
+
 use sig::{
     crypto::DefaultCrypto,
     keys::{PrivateKey, PublicKey},
     Address, Context, InternalError, PreKeyBundle, Serializable,
 };
-use std::time::{Duration, SystemTime};
+
+use crate::helpers::{
+    fake_random_generator, BasicIdentityKeyStore, BasicPreKeyStore,
+    BasicSessionStore, BasicSignedPreKeyStore, MockCrypto,
+};
+
+mod helpers;
 
 fn mock_ctx() -> Context {
     Context::new(
@@ -104,7 +107,7 @@ fn test_generate_pre_keys() {
 
 #[test]
 fn test_generate_signed_pre_key() {
-    const TIMESTAMP: u64 = 1411152577000;
+    const TIMESTAMP: u64 = 1_411_152_577_000;
 
     const SIGNED_PRE_KEY: &[u8] = &[
         0x08, 0xd2, 0x09, 0x12, 0x21, 0x05, 0x35, 0x80, 0x72, 0xd6, 0x36, 0x58,
@@ -161,7 +164,7 @@ fn test_curve25519_large_signatures() {
     let ctx = Context::default();
     let pair = sig::generate_key_pair(&ctx).unwrap();
 
-    let mut msg = vec![0; 1048576];
+    let mut msg = vec![0; 1_048_576];
     let private = pair.private().unwrap();
 
     let signature = sig::calculate_signature(&ctx, &private, &msg).unwrap();
@@ -290,7 +293,7 @@ fn test_basic_pre_key_v2() {
     let bob_identity_key_pair = sig::generate_identity_key_pair(&ctx).unwrap();
     let bob_pre_key_pair = sig::generate_key_pair(&ctx).unwrap();
 
-    let bob_public_identity_key_pair = bob_identity_key_pair.public().unwrap();
+    let bob_public_identity_key_pair = bob_identity_key_pair.public();
     let bob_public_pre_key = bob_pre_key_pair.public().unwrap();
     let bob_pre_key_bundle = PreKeyBundle::builder()
         .registration_id(registration_id)


### PR DESCRIPTION
as stated in #24 i'm working in implementing every store as in memory store.

- [x] `IdentityKeyStore` -> `InMemoryIdentityKeyStore`.
- [ ]  `PreKeyStore` -> `InMemoryPreKeyStore`.
- [ ] `SessionStore` -> `InMemorySessionStore`.
- [ ] `SignedPreKeyStore` -> `InMemorySignedPreKeyStore`.

I also refactored some of other code related to the `Context` and `IdentityKeyStore`.