### PR TITLE
Document more things

### DIFF
--- a/libsignal-protocol-sys/Cargo.toml
+++ b/libsignal-protocol-sys/Cargo.toml
@@ -7,6 +7,11 @@ license = "MIT OR Apache-2.0"
 readme = "../README.md"
 build = "build.rs"
 links = "signal-protocol"
+description = "*-sys crate for the libsignal-protocol-c library."
+repository = "https://github.com/Michael-F-Bryan/libsignal-protocol-rs"
+homepage = "https://github.com/Michael-F-Bryan/libsignal-protocol-rs"
+categories = ["external-ffi-bindings", "cryptography"]
+keywords = ["signal", "libsignal", "whisper", "protocol", "sys"]
 
 [build-dependencies]
 cmake = "0.1.38"

--- a/libsignal-protocol/Cargo.toml
+++ b/libsignal-protocol/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
+description = "An idiomatic high-level interface to the libsignal-protocol-c crate."
+homepage = "https://github.com/Michael-F-Bryan/libsignal-protocol-rs"
+repository = "https://github.com/Michael-F-Bryan/libsignal-protocol-rs"
+keywords = ["signal", "libsignal", "whisper", "protocol"]
+categories = ["api-bindings", "cryptography"]
 
 [dependencies]
 libsignal-protocol-sys = { path = "../libsignal-protocol-sys/" }

--- a/libsignal-protocol/examples/generate_keys.rs
+++ b/libsignal-protocol/examples/generate_keys.rs
@@ -54,7 +54,6 @@ fn main() -> Result<(), Error> {
     let pre_keys = sig::generate_pre_keys(&ctx, start, pre_key_count)?;
 
     let pre_key_ids: Vec<_> = pre_keys
-        .iter()
         .map(|session_key| session_key.id())
         .collect();
 

--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), Error> {
     let bob_address = Address::new("+14159998888", 1);
     let bob_identity_keys = sig::generate_identity_key_pair(&ctx)
         .context("Unable to generate bob's keys")?;
-    let bob_public_identity_key = bob_identity_keys.public()?;
+    let bob_public_identity_key = bob_identity_keys.public();
     let bob_pre_keys: Vec<_> = sig::generate_pre_keys(&ctx, 0, 10)
         .context("Unable to generate bob's pre-keys")?
         .iter()

--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -96,10 +96,10 @@ fn main() -> Result<(), Error> {
         .registration_id(42)
         .device_id(bob_address.device_id())
         .identity_key(&bob_public_identity_key)
-        .pre_key(pre_key.id(), &pre_key.key_pair().public()?)
+        .pre_key(pre_key.id(), &pre_key.key_pair().public())
         .signed_pre_key(
             bob_signed_pre_key.id(),
-            &bob_signed_pre_key.key_pair().public()?,
+            &bob_signed_pre_key.key_pair().public(),
         )
         .signature(bob_signed_pre_key.signature())
         .build()

--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -68,7 +68,6 @@ fn main() -> Result<(), Error> {
     let bob_public_identity_key = bob_identity_keys.public();
     let bob_pre_keys: Vec<_> = sig::generate_pre_keys(&ctx, 0, 10)
         .context("Unable to generate bob's pre-keys")?
-        .iter()
         .collect();
     let pre_key = &bob_pre_keys[0];
     let bob_signed_pre_key = sig::generate_signed_pre_key(

--- a/libsignal-protocol/src/address.rs
+++ b/libsignal-protocol/src/address.rs
@@ -24,10 +24,10 @@ impl<'a> Address<'a> {
     }
 
     /// Create a new [`Address`] from the raw struct.
-    /// 
+    ///
     /// # Safety
-    /// 
-    /// The `name` pointed to by the [`sys::signal_protocol_address`] must 
+    ///
+    /// The `name` pointed to by the [`sys::signal_protocol_address`] must
     /// outlive this [`Address`].
     pub(crate) unsafe fn from_raw(
         raw: sys::signal_protocol_address,
@@ -39,9 +39,9 @@ impl<'a> Address<'a> {
     }
 
     /// Create an [`Address`] from a pointer to the raw struct.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// (See the notes on [`Address::from_raw`])
     pub(crate) unsafe fn from_ptr(
         raw: *const sys::signal_protocol_address,

--- a/libsignal-protocol/src/address.rs
+++ b/libsignal-protocol/src/address.rs
@@ -29,7 +29,7 @@ impl<'a> Address<'a> {
     ///
     /// The `name` pointed to by the [`sys::signal_protocol_address`] must
     /// outlive this [`Address`].
-    pub(crate) unsafe fn from_raw(
+    pub(crate) const unsafe fn from_raw(
         raw: sys::signal_protocol_address,
     ) -> Address<'a> {
         Address {

--- a/libsignal-protocol/src/address.rs
+++ b/libsignal-protocol/src/address.rs
@@ -1,12 +1,18 @@
 use libsignal_protocol_sys as sys;
-use std::{marker::PhantomData, os::raw::c_char};
+use std::{
+    fmt::{self, Debug, Formatter},
+    marker::PhantomData,
+    os::raw::c_char,
+};
 
+/// A reference to a signal address (recipient name, device ID tuple).
 pub struct Address<'a> {
     raw: sys::signal_protocol_address,
     _string_lifetime: PhantomData<&'a ()>,
 }
 
 impl<'a> Address<'a> {
+    /// Create a new [`Address`].
     pub fn new(name: &'a str, device_id: i32) -> Address<'a> {
         let raw = sys::signal_protocol_address {
             name: name.as_ptr() as *const c_char,
@@ -17,6 +23,12 @@ impl<'a> Address<'a> {
         unsafe { Address::from_raw(raw) }
     }
 
+    /// Create a new [`Address`] from the raw struct.
+    /// 
+    /// # Safety
+    /// 
+    /// The `name` pointed to by the [`sys::signal_protocol_address`] must 
+    /// outlive this [`Address`].
     pub(crate) unsafe fn from_raw(
         raw: sys::signal_protocol_address,
     ) -> Address<'a> {
@@ -26,6 +38,11 @@ impl<'a> Address<'a> {
         }
     }
 
+    /// Create an [`Address`] from a pointer to the raw struct.
+    /// 
+    /// # Safety
+    /// 
+    /// (See the notes on [`Address::from_raw`])
     pub(crate) unsafe fn from_ptr(
         raw: *const sys::signal_protocol_address,
     ) -> Address<'a> {
@@ -40,6 +57,10 @@ impl<'a> Address<'a> {
         &self.raw
     }
 
+    /// Get a string of bytes identifying a recipient (usually their name as a
+    /// utf-8 string).
+    ///
+    /// You may also be looking for the [`Address::as_str`] method.
     pub fn bytes(&self) -> &[u8] {
         unsafe {
             std::slice::from_raw_parts(
@@ -49,21 +70,40 @@ impl<'a> Address<'a> {
         }
     }
 
+    /// Get the name attached to this address, converted to a `&str`.
     pub fn as_str(&self) -> Result<&str, std::str::Utf8Error> {
         std::str::from_utf8(self.bytes())
     }
 
+    /// Get the device ID attached to this address.
     pub fn device_id(&self) -> i32 { self.raw.device_id }
 }
 
 impl<'a> Clone for Address<'a> {
     fn clone(&self) -> Address<'a> {
         unsafe {
-        Address::from_raw(sys::signal_protocol_address {
-            name: self.raw.name,
-            name_len: self.raw.name_len,
-            device_id: self.raw.device_id,
-        })
+            Address::from_raw(sys::signal_protocol_address {
+                name: self.raw.name,
+                name_len: self.raw.name_len,
+                device_id: self.raw.device_id,
+            })
+        }
     }
 }
+
+impl<'a> Debug for Address<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_struct("Address");
+
+        match self.as_str() {
+            Ok(name) => {
+                f.field("name", &name);
+            },
+            Err(_) => {
+                f.field("name", &self.bytes());
+            },
+        }
+
+        f.field("device_id", &self.device_id()).finish()
+    }
 }

--- a/libsignal-protocol/src/address.rs
+++ b/libsignal-protocol/src/address.rs
@@ -14,17 +14,19 @@ impl<'a> Address<'a> {
             device_id,
         };
 
-        Address::from_raw(raw)
+        unsafe { Address::from_raw(raw) }
     }
 
-    pub fn from_raw(raw: sys::signal_protocol_address) -> Address<'a> {
+    pub(crate) unsafe fn from_raw(
+        raw: sys::signal_protocol_address,
+    ) -> Address<'a> {
         Address {
             raw,
             _string_lifetime: PhantomData,
         }
     }
 
-    pub unsafe fn from_ptr(
+    pub(crate) unsafe fn from_ptr(
         raw: *const sys::signal_protocol_address,
     ) -> Address<'a> {
         Address::from_raw(sys::signal_protocol_address {
@@ -56,10 +58,12 @@ impl<'a> Address<'a> {
 
 impl<'a> Clone for Address<'a> {
     fn clone(&self) -> Address<'a> {
+        unsafe {
         Address::from_raw(sys::signal_protocol_address {
             name: self.raw.name,
             name_len: self.raw.name_len,
             device_id: self.raw.device_id,
         })
     }
+}
 }

--- a/libsignal-protocol/src/buffer.rs
+++ b/libsignal-protocol/src/buffer.rs
@@ -15,7 +15,7 @@ impl Buffer {
     /// Create a new empty buffer.
     pub fn new() -> Buffer { Buffer::with_capacity(0) }
 
-    pub unsafe fn from_raw(raw: *mut sys::signal_buffer) -> Buffer {
+    pub(crate) unsafe fn from_raw(raw: *mut sys::signal_buffer) -> Buffer {
         assert!(!raw.is_null());
         Buffer { raw }
     }

--- a/libsignal-protocol/src/buffer.rs
+++ b/libsignal-protocol/src/buffer.rs
@@ -106,7 +106,9 @@ impl Default for Buffer {
 }
 
 impl Debug for Buffer {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result { self.as_slice().fmt(f) }
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.as_slice().fmt(f)
+    }
 }
 
 impl From<Vec<u8>> for Buffer {

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -210,6 +210,7 @@ pub fn session_builder(
 ///
 /// Most functions which require access to the global context (e.g. for crypto
 /// functions or locking) will accept a `&Context` as their first argument.
+#[derive(Debug, Clone)]
 pub struct Context(pub(crate) Rc<ContextInner>);
 
 impl Context {

--- a/libsignal-protocol/src/crypto/mod.rs
+++ b/libsignal-protocol/src/crypto/mod.rs
@@ -25,14 +25,18 @@ use crate::{
 };
 
 /// The error returned from a failed conversion to [`SignalCipherType`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct SignalCipherTypeError(i32);
 
-#[derive(Copy, Clone)]
-pub enum CipherMode {
+#[derive(Debug, Copy, Clone)]
+enum CipherMode {
     Encrypt,
     Decrypt,
 }
+
+/// The type of AES cipher.
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
 pub enum SignalCipherType {
     AesCtrNoPadding,
     AesCbcPkcs5,

--- a/libsignal-protocol/src/crypto/native.rs
+++ b/libsignal-protocol/src/crypto/native.rs
@@ -8,6 +8,7 @@ use sha2::{Digest, Sha256, Sha512};
 // Create alias for HMAC-SHA256
 type HmacSha256 = Hmac<Sha256>;
 
+/// Cryptography routines using native Rust crates.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct DefaultCrypto;
 

--- a/libsignal-protocol/src/crypto/openssl.rs
+++ b/libsignal-protocol/src/crypto/openssl.rs
@@ -8,6 +8,7 @@ use openssl::{
     symm::{Cipher, Crypter, Mode},
 };
 
+#[derive(Debug, Copy, Clone)]
 pub struct OpenSSLCrypto;
 
 impl OpenSSLCrypto {
@@ -61,7 +62,7 @@ impl Crypto for OpenSSLCrypto {
 
     fn hmac_sha256(
         &self,
-        key: &[u8],
+        _key: &[u8],
     ) -> Result<Box<dyn Sha256Hmac>, InternalError> {
         let nid = Nid::HMACWITHSHA256;
         let ty = MessageDigest::from_nid(nid)

--- a/libsignal-protocol/src/crypto/openssl.rs
+++ b/libsignal-protocol/src/crypto/openssl.rs
@@ -1,6 +1,6 @@
 use crate::{
     crypto::{Crypto, Sha256Hmac, Sha512Digest, SignalCipherType},
-    errors::{FromInternalErrorCode, InternalError, IntoInternalErrorCode},
+    errors::InternalError,
 };
 use openssl::{
     hash::{Hasher, MessageDigest},
@@ -8,6 +8,7 @@ use openssl::{
     symm::{Cipher, Crypter, Mode},
 };
 
+/// Cryptography routines built on top of the system's `openssl` library.
 #[derive(Debug, Copy, Clone)]
 pub struct OpenSSLCrypto;
 

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, failure_derive::Fail)]
+#[allow(missing_docs)]
 pub enum InternalError {
     NoMemory,
     InvalidArgument,
@@ -26,6 +27,7 @@ pub enum InternalError {
 }
 
 impl InternalError {
+    /// Try to figure out what type of error a code corresponds to.
     pub fn from_error_code(code: i32) -> Option<InternalError> {
         match code {
             sys::SG_ERR_NOMEM => Some(InternalError::NoMemory),
@@ -63,6 +65,7 @@ impl InternalError {
         }
     }
 
+    /// Get the code which corresponds to this error.
     pub fn code(self) -> i32 {
         match self {
             InternalError::NoMemory => sys::SG_ERR_NOMEM,
@@ -87,24 +90,17 @@ impl InternalError {
             InternalError::Other(c) => c,
         }
     }
-
-    pub fn into_result(self, code: i32) -> Result<(), InternalError> {
-        if code == 0 {
-            return Ok(());
-        }
-
-        match InternalError::from_error_code(code) {
-            None => Ok(()),
-            Some(e) => Err(e),
-        }
-    }
 }
 
+/// A helper trait for going from an [`InternalError`] to a `Result`.
 pub trait FromInternalErrorCode: Sized {
+    /// Make the conversion.
     fn into_result(self) -> Result<(), InternalError>;
 }
 
+/// A helper trait for going from a `Result` to an [`InternalError`].
 pub trait IntoInternalErrorCode: Sized {
+    /// Make the conversion.
     fn into_code(self) -> i32;
 }
 

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -133,7 +133,7 @@ impl<T> IntoInternalErrorCode for Result<T, InternalError> {
 }
 
 impl Display for InternalError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             InternalError::NoMemory => write!(f, "No Memory"),
             InternalError::InvalidArgument => write!(f, "Invalid argument"),

--- a/libsignal-protocol/src/hkdf.rs
+++ b/libsignal-protocol/src/hkdf.rs
@@ -12,7 +12,7 @@ pub struct HMACBasedKeyDerivationFunction {
 }
 
 impl HMACBasedKeyDerivationFunction {
-    pub fn new(
+    pub(crate) fn new(
         version: i32,
         ctx: &Context,
     ) -> Result<HMACBasedKeyDerivationFunction, Error> {
@@ -28,6 +28,8 @@ impl HMACBasedKeyDerivationFunction {
         }
     }
 
+    /// Derive a new secret by cryptographically "stretching" the provided
+    /// information to the expected length.
     pub fn derive_secrets(
         &self,
         secret_length: usize,

--- a/libsignal-protocol/src/identity_key_store.rs
+++ b/libsignal-protocol/src/identity_key_store.rs
@@ -1,8 +1,9 @@
 use crate::{errors::InternalError, Address, Buffer};
 use std::os::raw::{c_int, c_void};
 
+/// Something used to store identity keys and track trusted identities.
 pub trait IdentityKeyStore {
-    // Get the local client's identity key pair.
+    /// Get the local client's identity key pair.
     fn identity_key_pair(&self) -> Result<(Buffer, Buffer), InternalError>;
 
     /// Get the local client's registration ID.

--- a/libsignal-protocol/src/keys/identity_key_pair.rs
+++ b/libsignal-protocol/src/keys/identity_key_pair.rs
@@ -9,11 +9,13 @@ use std::{
     ptr,
 };
 
+/// A "ratcheting" key pair.
 pub struct IdentityKeyPair {
     pub(crate) raw: Raw<sys::ratchet_identity_key_pair>,
 }
 
 impl IdentityKeyPair {
+    /// Create a new [`IdentityKeyPair`] out of its public and private keys.
     pub fn new(
         public_key: &PublicKey,
         private_key: &PrivateKey,
@@ -33,6 +35,7 @@ impl IdentityKeyPair {
         }
     }
 
+    /// Get the public part of this key pair.
     pub fn public(&self) -> PublicKey {
         unsafe {
             let raw = sys::ratchet_identity_key_pair_get_public(
@@ -45,6 +48,7 @@ impl IdentityKeyPair {
         }
     }
 
+    /// Get the public part of this key pair.
     pub fn private(&self) -> PrivateKey {
         unsafe {
             let raw = sys::ratchet_identity_key_pair_get_private(

--- a/libsignal-protocol/src/keys/identity_key_pair.rs
+++ b/libsignal-protocol/src/keys/identity_key_pair.rs
@@ -4,7 +4,10 @@ use crate::{
     raw_ptr::Raw,
 };
 use failure::Error;
-use std::ptr;
+use std::{
+    fmt::{self, Debug, Formatter},
+    ptr,
+};
 
 pub struct IdentityKeyPair {
     pub(crate) raw: Raw<sys::ratchet_identity_key_pair>,
@@ -30,16 +33,37 @@ impl IdentityKeyPair {
         }
     }
 
-    pub fn public(&self) -> Result<PublicKey, Error> {
+    pub fn public(&self) -> PublicKey {
         unsafe {
             let raw = sys::ratchet_identity_key_pair_get_public(
                 self.raw.as_const_ptr(),
             );
             assert!(!raw.is_null());
-            Ok(PublicKey {
+            PublicKey {
                 raw: Raw::copied_from(raw),
-            })
+            }
         }
+    }
+
+    pub fn private(&self) -> PrivateKey {
+        unsafe {
+            let raw = sys::ratchet_identity_key_pair_get_private(
+                self.raw.as_const_ptr(),
+            );
+            assert!(!raw.is_null());
+            PrivateKey {
+                raw: Raw::copied_from(raw),
+            }
+        }
+    }
+}
+
+impl Debug for IdentityKeyPair {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IdentityKeyPair")
+            .field("public", &self.public())
+            .field("private", &self.private())
+            .finish()
     }
 }
 

--- a/libsignal-protocol/src/keys/key_pair.rs
+++ b/libsignal-protocol/src/keys/key_pair.rs
@@ -4,14 +4,19 @@ use crate::{
     raw_ptr::Raw,
 };
 use failure::Error;
-use std::ptr;
+use std::{
+    fmt::{self, Debug, Formatter},
+    ptr,
+};
 
+/// A public-private key pair.
 #[derive(Clone)]
 pub struct KeyPair {
     pub(crate) raw: Raw<sys::ec_key_pair>,
 }
 
 impl KeyPair {
+    /// Create a new [`KeyPair`] from its public and private keys.
     pub fn new(
         public_key: &PublicKey,
         private_key: &PrivateKey,
@@ -31,31 +36,36 @@ impl KeyPair {
         }
     }
 
-    pub fn public(&self) -> Result<PublicKey, Error> {
+    /// Get the public key.
+    pub fn public(&self) -> PublicKey {
         unsafe {
             let raw = sys::ec_key_pair_get_public(self.raw.as_ptr());
+            assert!(!raw.is_null());
 
-            if raw.is_null() {
-                Err(failure::err_msg("Unable to get the public key"))
-            } else {
-                Ok(PublicKey {
-                    raw: Raw::copied_from(raw),
-                })
+            PublicKey {
+                raw: Raw::copied_from(raw),
             }
         }
     }
 
-    pub fn private(&self) -> Result<PrivateKey, Error> {
+    /// Get the private key.
+    pub fn private(&self) -> PrivateKey {
         unsafe {
             let raw = sys::ec_key_pair_get_private(self.raw.as_ptr());
+            assert!(!raw.is_null());
 
-            if raw.is_null() {
-                Err(failure::err_msg("Unable to get the private key"))
-            } else {
-                Ok(PrivateKey {
-                    raw: Raw::copied_from(raw),
-                })
+            PrivateKey {
+                raw: Raw::copied_from(raw),
             }
         }
+    }
+}
+
+impl Debug for KeyPair {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyPair")
+            .field("public", &self.public())
+            .field("private", &"<elided>")
+            .finish()
     }
 }

--- a/libsignal-protocol/src/keys/mod.rs
+++ b/libsignal-protocol/src/keys/mod.rs
@@ -1,3 +1,5 @@
+//! Elliptic curve cryptography keys.
+
 mod identity_key_pair;
 mod key_pair;
 mod pre_key;

--- a/libsignal-protocol/src/keys/pre_key.rs
+++ b/libsignal-protocol/src/keys/pre_key.rs
@@ -1,13 +1,18 @@
 use crate::{errors::FromInternalErrorCode, keys::KeyPair, raw_ptr::Raw};
 use failure::Error;
-use std::ptr;
+use std::{
+    fmt::{self, Debug, Formatter},
+    ptr,
+};
 
+/// An unsigned pre-key.
 #[derive(Clone)]
 pub struct PreKey {
     pub(crate) raw: Raw<sys::session_pre_key>,
 }
 
 impl PreKey {
+    /// Create a new pre-key based on an identity key-pair.
     pub fn new(id: u32, key_pair: &KeyPair) -> Result<PreKey, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
@@ -20,10 +25,12 @@ impl PreKey {
         }
     }
 
+    /// Get the pre-key ID.
     pub fn id(&self) -> u32 {
         unsafe { sys::session_pre_key_get_id(self.raw.as_const_ptr()) }
     }
 
+    /// Get this pre-key's key pair.
     pub fn key_pair(&self) -> KeyPair {
         unsafe {
             let raw =
@@ -37,3 +44,12 @@ impl PreKey {
 }
 
 impl_serializable!(PreKey, session_pre_key_serialize, foo);
+
+impl Debug for PreKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreKey")
+            .field("key_pair", &self.key_pair())
+            .field("id", &self.id())
+            .finish()
+    }
+}

--- a/libsignal-protocol/src/keys/pre_key_list.rs
+++ b/libsignal-protocol/src/keys/pre_key_list.rs
@@ -1,5 +1,8 @@
 use crate::{keys::PreKey, raw_ptr::Raw};
-use std::marker::PhantomData;
+use std::{
+    fmt::{self, Debug, Formatter},
+    marker::PhantomData,
+};
 
 pub struct PreKeyList {
     head: *mut sys::signal_protocol_key_helper_pre_key_list_node,
@@ -25,6 +28,12 @@ impl Drop for PreKeyList {
         unsafe {
             sys::signal_protocol_key_helper_key_list_free(self.head);
         }
+    }
+}
+
+impl Debug for PreKeyList {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PreKeyList").finish()
     }
 }
 

--- a/libsignal-protocol/src/keys/private.rs
+++ b/libsignal-protocol/src/keys/private.rs
@@ -7,12 +7,14 @@ use std::{
     ptr,
 };
 
+/// The private half of an elliptic curve key pair.
 #[derive(Clone, Debug)]
 pub struct PrivateKey {
     pub(crate) raw: Raw<sys::ec_private_key>,
 }
 
 impl PrivateKey {
+    /// Decode a [`PrivateKey`] from raw key data.
     pub fn decode_point(
         ctx: &Context,
         key: &[u8],
@@ -33,6 +35,7 @@ impl PrivateKey {
         }
     }
 
+    /// Derive the public part of this key pair.
     pub fn generate_public_key(&self) -> Result<PublicKey, Error> {
         unsafe {
             let mut raw = ptr::null_mut();

--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -9,12 +9,14 @@ use std::{
     ptr,
 };
 
+/// The public part of an elliptic curve key pair.
 #[derive(Clone, Debug)]
 pub struct PublicKey {
     pub(crate) raw: Raw<sys::ec_public_key>,
 }
 
 impl PublicKey {
+    /// Deserialize a [`PublicKey`] from the raw key data.
     pub fn decode_point(ctx: &Context, key: &[u8]) -> Result<PublicKey, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
@@ -32,6 +34,7 @@ impl PublicKey {
         }
     }
 
+    /// Use this public key to check whether a message matches its signature.
     pub fn verify_signature(
         &self,
         message: &[u8],

--- a/libsignal-protocol/src/keys/signed_pre_key.rs
+++ b/libsignal-protocol/src/keys/signed_pre_key.rs
@@ -1,9 +1,9 @@
 use crate::{errors::FromInternalErrorCode, keys::KeyPair, raw_ptr::Raw};
 use failure::Error;
 use std::{
+    fmt::{self, Debug, Formatter},
     ptr,
     time::{Duration, SystemTime},
-    fmt::{self, Debug, Formatter},
 };
 
 /// A signed pre-key.

--- a/libsignal-protocol/src/keys/signed_pre_key.rs
+++ b/libsignal-protocol/src/keys/signed_pre_key.rs
@@ -3,13 +3,18 @@ use failure::Error;
 use std::{
     ptr,
     time::{Duration, SystemTime},
+    fmt::{self, Debug, Formatter},
 };
 
+/// A signed pre-key.
+#[derive(Clone)]
 pub struct SessionSignedPreKey {
     pub(crate) raw: Raw<sys::session_signed_pre_key>,
 }
 
 impl SessionSignedPreKey {
+    /// Create a new [`SessionSignedPreKey`] out of an existing [`KeyPair`] and
+    /// its signature.
     pub fn new(
         id: u32,
         timestamp: SystemTime,
@@ -36,10 +41,12 @@ impl SessionSignedPreKey {
         }
     }
 
+    /// Get the signed pre-key's ID.
     pub fn id(&self) -> u32 {
         unsafe { sys::session_signed_pre_key_get_id(self.raw.as_const_ptr()) }
     }
 
+    /// When was this key signed?
     pub fn timestamp(&self) -> SystemTime {
         unsafe {
             let ts = sys::session_signed_pre_key_get_timestamp(
@@ -49,6 +56,7 @@ impl SessionSignedPreKey {
         }
     }
 
+    /// Get the key pair which has been signed.
     pub fn key_pair(&self) -> KeyPair {
         unsafe {
             let raw = sys::session_signed_pre_key_get_key_pair(
@@ -61,6 +69,7 @@ impl SessionSignedPreKey {
         }
     }
 
+    /// Get the signature.
     pub fn signature(&self) -> &[u8] {
         unsafe {
             let len = sys::session_signed_pre_key_get_signature_len(
@@ -76,3 +85,13 @@ impl SessionSignedPreKey {
 }
 
 impl_serializable!(SessionSignedPreKey, session_signed_pre_key_serialize, foo);
+
+impl Debug for SessionSignedPreKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionSignedPreKey")
+            .field("key_pair", &self.key_pair())
+            .field("id", &self.id())
+            .field("timestamp", &self.timestamp())
+            .finish()
+    }
+}

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -61,6 +61,8 @@
     clippy::missing_const_for_fn
 )]
 
+// we use the *-sys crate everywhere so give it a shorter name
+#[allow(unused_extern_crates)]
 extern crate libsignal_protocol_sys as sys;
 
 pub use crate::{

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Sessions
 //!
-//! The Signal Protocol is session-oriented. Clients establish a "session,"
+//! The Signal Protocol is session-oriented. Clients establish a "session"
 //! which is then used for all subsequent encrypt/decrypt operations. There is
 //! no need to ever tear down a session once one has been established.
 //!

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -53,7 +53,12 @@
 #![deny(
     missing_docs,
     missing_debug_implementations,
-    missing_copy_implementations
+    missing_copy_implementations,
+    elided_lifetimes_in_paths,
+    rust_2018_idioms,
+    clippy::cargo_common_metadata,
+    clippy::fallible_impl_from,
+    clippy::missing_const_for_fn
 )]
 
 extern crate libsignal_protocol_sys as sys;

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -50,6 +50,12 @@
 //!
 //! [libsignal-protocol-c]: https://github.com/signalapp/libsignal-protocol-c
 
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations
+)]
+
 extern crate libsignal_protocol_sys as sys;
 
 pub use crate::{
@@ -92,13 +98,17 @@ mod store_context;
 use failure::Error;
 use std::io::Write;
 
+/// A helper trait for something which can be serialized to protobufs.
 pub trait Serializable {
+    /// Serialize the object to a buffer.
     fn serialize(&self) -> Result<Buffer, Error>;
 
+    /// Parse the provided data in the protobuf format.
     fn deserialize(data: &[u8]) -> Result<Self, Error>
     where
         Self: Sized;
 
+    /// Helper for serializing to anything which implements [`Write`].
     fn serialize_to<W: Write>(&self, mut writer: W) -> Result<(), Error> {
         let buffer = self.serialize()?;
         writer.write_all(buffer.as_slice())?;

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -23,8 +23,8 @@
 //! Sessions are established in one of three ways:
 //!
 //! 1. [`PreKeyBundle`]. A client that wishes to send a message to a recipient
-//!    can establish a session by retrieving a PreKeyBundle for that recipient
-//!    from the server.
+//!    can establish a session by retrieving a [`PreKeyBundle`] for that
+//!    recipient from the server.
 //! 2. PreKeySignalMessages.  A client can receive a PreKeySignalMessage from a
 //!    recipient and use it to establish a session.
 //! 3. KeyExchangeMessages.  Two clients can exchange KeyExchange messages to

--- a/libsignal-protocol/src/messages/ciphertext_message.rs
+++ b/libsignal-protocol/src/messages/ciphertext_message.rs
@@ -1,5 +1,6 @@
 use crate::{raw_ptr::Raw, Buffer, Serializable};
 
+/// An encrypted message ("ciphertext").
 #[derive(Debug, Clone)]
 pub struct CiphertextMessage {
     pub(crate) raw: Raw<sys::ciphertext_message>,

--- a/libsignal-protocol/src/messages/mod.rs
+++ b/libsignal-protocol/src/messages/mod.rs
@@ -1,3 +1,5 @@
+//! Common message types.
+
 mod ciphertext_message;
 
 pub use self::ciphertext_message::CiphertextMessage;

--- a/libsignal-protocol/src/pre_key_bundle.rs
+++ b/libsignal-protocol/src/pre_key_bundle.rs
@@ -1,15 +1,21 @@
 use crate::{keys::PublicKey, raw_ptr::Raw};
 use failure::Error;
-use std::ptr;
+use std::{
+    fmt::{self, Debug, Formatter},
+    ptr,
+};
 
+/// The session state used when sending a message to another user.
 #[derive(Clone)]
 pub struct PreKeyBundle {
     pub(crate) raw: Raw<sys::session_pre_key_bundle>,
 }
 
 impl PreKeyBundle {
+    /// Get a builder struct for the [`PreKeyBundle`].
     pub fn builder() -> PreKeyBundleBuilder { PreKeyBundleBuilder::default() }
 
+    /// Get the registration ID.
     pub fn registration_id(&self) -> u32 {
         unsafe {
             sys::session_pre_key_bundle_get_registration_id(
@@ -18,18 +24,21 @@ impl PreKeyBundle {
         }
     }
 
+    /// Get the device ID.
     pub fn device_id(&self) -> i32 {
         unsafe {
             sys::session_pre_key_bundle_get_device_id(self.raw.as_const_ptr())
         }
     }
 
+    /// Get the pre-key ID.
     pub fn pre_key_id(&self) -> u32 {
         unsafe {
             sys::session_pre_key_bundle_get_pre_key_id(self.raw.as_const_ptr())
         }
     }
 
+    /// Get the pre-key itself.
     pub fn pre_key(&self) -> Result<PublicKey, Error> {
         unsafe {
             let raw = sys::session_pre_key_bundle_get_pre_key(
@@ -45,6 +54,7 @@ impl PreKeyBundle {
         }
     }
 
+    /// Get the signed pre-key id.
     pub fn signed_pre_key_id(&self) -> u32 {
         unsafe {
             sys::session_pre_key_bundle_get_signed_pre_key_id(
@@ -53,6 +63,7 @@ impl PreKeyBundle {
         }
     }
 
+    /// Get the signed pre-key.
     pub fn signed_pre_key(&self) -> Result<PublicKey, Error> {
         unsafe {
             let raw = sys::session_pre_key_bundle_get_signed_pre_key(
@@ -68,6 +79,7 @@ impl PreKeyBundle {
         }
     }
 
+    /// Get the identity key.
     pub fn identity_key(&self) -> Result<PublicKey, Error> {
         unsafe {
             let raw = sys::session_pre_key_bundle_get_identity_key(
@@ -84,7 +96,14 @@ impl PreKeyBundle {
     }
 }
 
-#[derive(Default)]
+impl Debug for PreKeyBundle {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PreKeyBundle").finish()
+    }
+}
+
+/// A builder type for the [`PreKeyBundle`].
+#[derive(Debug, Default)]
 pub struct PreKeyBundleBuilder {
     registration_id: Option<u32>,
     device_id: Option<i32>,
@@ -97,6 +116,7 @@ pub struct PreKeyBundleBuilder {
 }
 
 impl PreKeyBundleBuilder {
+    /// Set the recipient's public pre-key.
     pub fn pre_key(mut self, id: u32, public_key: &PublicKey) -> Self {
         self.pre_key_id = Some(id);
         self.pre_key_public = Some(public_key.clone());
@@ -104,6 +124,7 @@ impl PreKeyBundleBuilder {
         self
     }
 
+    /// Set the signed pre-key.
     pub fn signed_pre_key(
         mut self,
         id: u32,
@@ -115,21 +136,25 @@ impl PreKeyBundleBuilder {
         self
     }
 
+    /// Set the signed pre-key's signature.
     pub fn signature(mut self, sig: &[u8]) -> Self {
         self.signature = Some(sig.to_vec());
         self
     }
 
+    /// Set the registration ID.
     pub fn registration_id(mut self, id: u32) -> Self {
         self.registration_id = Some(id);
         self
     }
 
+    /// Set the device ID.
     pub fn device_id(mut self, id: i32) -> Self {
         self.device_id = Some(id);
         self
     }
 
+    /// Set the user's identity key.
     pub fn identity_key(mut self, identity_key: &PublicKey) -> Self {
         self.identity_key = Some(identity_key.clone());
         self
@@ -180,6 +205,7 @@ impl PreKeyBundleBuilder {
         }
     }
 
+    /// Actually build the [`PreKeyBundle`].
     pub fn build(self) -> Result<PreKeyBundle, Error> {
         let registration_id = self.get_registration_id()?;
         let device_id = self.get_device_id()?;

--- a/libsignal-protocol/src/pre_key_store.rs
+++ b/libsignal-protocol/src/pre_key_store.rs
@@ -4,10 +4,16 @@ use std::{
     os::raw::{c_int, c_void},
 };
 
+/// Something which can store [`crate::keys::PreKey`]s without inspecting their
+/// contents.
 pub trait PreKeyStore {
+    /// Load a pre-key.
     fn load(&self, id: u32, writer: &mut dyn Write) -> io::Result<()>;
+    /// Store a pre-key.
     fn store(&self, id: u32, body: &[u8]) -> Result<(), InternalError>;
+    /// Is the pre-key with this ID present in the store?
     fn contains(&self, id: u32) -> bool;
+    /// Remove a pre-key from the store.
     fn remove(&self, id: u32) -> Result<(), InternalError>;
 }
 

--- a/libsignal-protocol/src/session_builder.rs
+++ b/libsignal-protocol/src/session_builder.rs
@@ -11,6 +11,7 @@ use std::{
     rc::Rc,
 };
 
+/// Create a new session.
 pub struct SessionBuilder {
     raw: *mut sys::session_builder,
     // both these fields must outlive `session_builder`
@@ -19,6 +20,7 @@ pub struct SessionBuilder {
 }
 
 impl SessionBuilder {
+    /// Create a new session builder.
     pub fn new(
         ctx: &Context,
         store_context: &StoreContext,
@@ -41,6 +43,7 @@ impl SessionBuilder {
         }
     }
 
+    /// Build a session using a pre-key retrieved from the server.
     pub fn process_pre_key_bundle(
         &self,
         pre_key_bundle: &PreKeyBundle,

--- a/libsignal-protocol/src/session_builder.rs
+++ b/libsignal-protocol/src/session_builder.rs
@@ -5,7 +5,11 @@ use crate::{
     pre_key_bundle::PreKeyBundle,
     store_context::{StoreContext, StoreContextInner},
 };
-use std::{ptr, rc::Rc};
+use std::{
+    fmt::{self, Debug, Formatter},
+    ptr,
+    rc::Rc,
+};
 
 pub struct SessionBuilder {
     raw: *mut sys::session_builder,
@@ -56,5 +60,11 @@ impl Drop for SessionBuilder {
         unsafe {
             sys::session_builder_free(self.raw);
         }
+    }
+}
+
+impl Debug for SessionBuilder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SessionBuilder").finish()
     }
 }

--- a/libsignal-protocol/src/session_cipher.rs
+++ b/libsignal-protocol/src/session_cipher.rs
@@ -8,8 +8,13 @@ use crate::{
 };
 
 use failure::Error;
-use std::{ptr, rc::Rc};
+use std::{
+    fmt::{self, Debug, Formatter},
+    ptr,
+    rc::Rc,
+};
 
+/// The cipher context used for encryption.
 pub struct SessionCipher {
     raw: *mut sys::session_cipher,
     _ctx: Rc<ContextInner>,
@@ -17,6 +22,7 @@ pub struct SessionCipher {
 }
 
 impl SessionCipher {
+    /// Create a new cipher for sending messages to the addressed recipient.
     pub fn new(
         ctx: &Context,
         store_ctx: &StoreContext,
@@ -40,6 +46,7 @@ impl SessionCipher {
         }
     }
 
+    /// Encrypt a message.
     pub fn encrypt(&self, message: &[u8]) -> Result<CiphertextMessage, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
@@ -55,5 +62,11 @@ impl SessionCipher {
                 raw: Raw::from_ptr(raw),
             })
         }
+    }
+}
+
+impl Debug for SessionCipher {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SessionCipher").finish()
     }
 }

--- a/libsignal-protocol/src/session_store.rs
+++ b/libsignal-protocol/src/session_store.rs
@@ -1,12 +1,16 @@
 use crate::{errors::InternalError, Address, Buffer};
 use std::os::raw::{c_char, c_int, c_void};
 
+/// A serialized session.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SerializedSession {
+    /// The session itself.
     pub session: Buffer,
+    /// Extra data attached by the user (e.g. a name or other information).
     pub extra_data: Option<Buffer>,
 }
 
+/// Something which can store the sessions established with recipients.
 pub trait SessionStore {
     /// Get a copy of the serialized session record corresponding to the
     /// provided recipient [`Address`].

--- a/libsignal-protocol/src/signed_pre_key_store.rs
+++ b/libsignal-protocol/src/signed_pre_key_store.rs
@@ -4,10 +4,15 @@ use std::{
     os::raw::{c_int, c_void},
 };
 
+/// Something which can store signed pre-keys without inspecting their contents.
 pub trait SignedPreKeyStore {
+    /// Load a signed pre-key.
     fn load(&self, id: u32, writer: &mut dyn Write) -> io::Result<()>;
+    /// Store a signed pre-key.
     fn store(&self, id: u32, body: &[u8]) -> Result<(), InternalError>;
+    /// Is the signed pre-key with this ID present in the store?
     fn contains(&self, id: u32) -> bool;
+    /// Remove a signed pre-key from the store.
     fn remove(&self, id: u32) -> Result<(), InternalError>;
 }
 

--- a/libsignal-protocol/src/store_context.rs
+++ b/libsignal-protocol/src/store_context.rs
@@ -1,7 +1,11 @@
 use crate::{context::ContextInner, errors::FromInternalErrorCode};
 use failure::Error;
-use std::rc::Rc;
+use std::{
+    fmt::{self, Debug, Formatter},
+    rc::Rc,
+};
 
+#[derive(Debug, Clone)]
 pub struct StoreContext(pub(crate) Rc<StoreContextInner>);
 
 impl StoreContext {
@@ -15,6 +19,7 @@ impl StoreContext {
         }))
     }
 
+    /// Get the registration ID.
     pub fn registration_id(&self) -> Result<u32, Error> {
         unsafe {
             let mut id = 0;
@@ -45,5 +50,11 @@ impl Drop for StoreContextInner {
         unsafe {
             sys::signal_protocol_store_context_destroy(self.raw);
         }
+    }
+}
+
+impl Debug for StoreContextInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("StoreContextInner").finish()
     }
 }

--- a/libsignal-protocol/src/store_context.rs
+++ b/libsignal-protocol/src/store_context.rs
@@ -5,6 +5,10 @@ use std::{
     rc::Rc,
 };
 
+/// Something which contains state used by the signal protocol.
+///
+/// Under the hood this contains several "Stores" for various keys and session
+/// state (e.g. which identities are trusted, and their pre-keys).
 #[derive(Debug, Clone)]
 pub struct StoreContext(pub(crate) Rc<StoreContextInner>);
 

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -82,14 +82,13 @@ fn test_generate_pre_keys() {
 
     let ctx = mock_ctx();
 
-    let pre_keys = sig::generate_pre_keys(&ctx, 1, 4).unwrap();
-    let mut iter = pre_keys.iter();
+    let mut pre_keys = sig::generate_pre_keys(&ctx, 1, 4).unwrap();
 
-    let pre_key_1 = iter.next().unwrap();
-    let pre_key_2 = iter.next().unwrap();
-    let pre_key_3 = iter.next().unwrap();
-    let pre_key_4 = iter.next().unwrap();
-    assert!(iter.next().is_none());
+    let pre_key_1 = pre_keys.next().unwrap();
+    let pre_key_2 = pre_keys.next().unwrap();
+    let pre_key_3 = pre_keys.next().unwrap();
+    let pre_key_4 = pre_keys.next().unwrap();
+    assert!(pre_keys.next().is_none());
 
     let pre_key_1_serialized = pre_key_1.serialize().unwrap();
     let pre_key_2_serialized = pre_key_2.serialize().unwrap();

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -162,11 +162,11 @@ fn test_curve25519_large_signatures() {
     let pair = sig::generate_key_pair(&ctx).unwrap();
 
     let mut msg = vec![0; 1048576];
-    let private = pair.private().unwrap();
+    let private = pair.private();
 
     let signature = sig::calculate_signature(&ctx, &private, &msg).unwrap();
 
-    let public = pair.public().unwrap();
+    let public = pair.public();
     let got = public.verify_signature(&msg, signature.as_slice());
     assert!(got.is_ok());
 
@@ -291,7 +291,7 @@ fn test_basic_pre_key_v2() {
     let bob_pre_key_pair = sig::generate_key_pair(&ctx).unwrap();
 
     let bob_public_identity_key_pair = bob_identity_key_pair.public().unwrap();
-    let bob_public_pre_key = bob_pre_key_pair.public().unwrap();
+    let bob_public_pre_key = bob_pre_key_pair.public();
     let bob_pre_key_bundle = PreKeyBundle::builder()
         .registration_id(registration_id)
         .device_id(1)

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -290,7 +290,7 @@ fn test_basic_pre_key_v2() {
     let bob_identity_key_pair = sig::generate_identity_key_pair(&ctx).unwrap();
     let bob_pre_key_pair = sig::generate_key_pair(&ctx).unwrap();
 
-    let bob_public_identity_key_pair = bob_identity_key_pair.public().unwrap();
+    let bob_public_identity_key_pair = bob_identity_key_pair.public();
     let bob_public_pre_key = bob_pre_key_pair.public();
     let bob_pre_key_bundle = PreKeyBundle::builder()
         .registration_id(registration_id)


### PR DESCRIPTION
This adds the `#[deny(missing_docs)]` lint and some initial documentation for most types.

At some point we'll want to go back and add examples to selected items, but I'll leave that for a later PR.

I've also included some minor drive-by refactorings like adding `unsafe` to `Address::from_raw()` and changing `KeyPair::public()` to return the public key directly instead of a `Result` (if a key pair doesn't have half the pair then changes are something bad has happened....).