### PR TITLE
Told travis that the "Code Style" build is allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,17 @@ before_deploy:
   - cp -r target/doc public
 
 matrix:
+  fast_finish: true
+  allow_failures:
+    - name: "Code Style"
+
   include:
     - rust: stable
     - rust: 1.34.0
     - rust: nightly
+
+    - rust: nightly
+      name: "Code Style"
       before_script:
         - rustup component add rustfmt
         - rustup component add clippy


### PR DESCRIPTION
This is starting to get annoying. #30 has been blocked for several days because `clippy` is broken on `nightly`. I think the best course of action is to ignore the failed `"Code Style"` builds...