### PR TITLE
Owned addresses

### DIFF
--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -89,7 +89,7 @@ fn main() -> Result<(), Error> {
 
     // Instantiate a session_builder for a recipient address.
     let alice_session_builder =
-        SessionBuilder::new(&ctx, &alice_store_ctx, bob_address.clone());
+        SessionBuilder::new(&ctx, &alice_store_ctx, &bob_address);
 
     let pre_key_bundle = PreKeyBundle::builder()
         .registration_id(42)
@@ -112,7 +112,7 @@ fn main() -> Result<(), Error> {
     // Now we've established a session alice can start encrypting messages to
     // send to bob
     let cipher =
-        SessionCipher::new(&ctx, &alice_store_ctx, bob_address.clone())?;
+        SessionCipher::new(&ctx, &alice_store_ctx, &bob_address)?;
     let message = "Hello, World!";
     let encrypted_message = cipher
         .encrypt(message.as_bytes())

--- a/libsignal-protocol/src/address.rs
+++ b/libsignal-protocol/src/address.rs
@@ -1,26 +1,20 @@
 use libsignal_protocol_sys as sys;
 use std::{
     fmt::{self, Debug, Formatter},
-    marker::PhantomData,
+    hash::{Hash, Hasher},
     os::raw::c_char,
+    pin::Pin,
+    rc::Rc,
 };
 
-/// A reference to a signal address (recipient name, device ID tuple).
-pub struct Address<'a> {
-    raw: sys::signal_protocol_address,
-    _string_lifetime: PhantomData<&'a ()>,
-}
+/// A reference-counted pointer to a signal address (recipient name, device ID
+/// tuple).
+pub struct Address(Rc<OwnedAddress>);
 
-impl<'a> Address<'a> {
+impl Address {
     /// Create a new [`Address`].
-    pub fn new(name: &'a str, device_id: i32) -> Address<'a> {
-        let raw = sys::signal_protocol_address {
-            name: name.as_ptr() as *const c_char,
-            name_len: name.len(),
-            device_id,
-        };
-
-        unsafe { Address::from_raw(raw) }
+    pub fn new<N: AsRef<[u8]>>(name: N, device_id: i32) -> Address {
+        Address(Rc::new(OwnedAddress::new(name.as_ref(), device_id)))
     }
 
     /// Create a new [`Address`] from the raw struct.
@@ -29,13 +23,12 @@ impl<'a> Address<'a> {
     ///
     /// The `name` pointed to by the [`sys::signal_protocol_address`] must
     /// outlive this [`Address`].
-    pub(crate) const unsafe fn from_raw(
+    pub(crate) unsafe fn from_raw(
         raw: sys::signal_protocol_address,
-    ) -> Address<'a> {
-        Address {
-            raw,
-            _string_lifetime: PhantomData,
-        }
+    ) -> Address {
+        let name =
+            std::slice::from_raw_parts(raw.name as *const _, raw.name_len);
+        Address::new(name, raw.device_id)
     }
 
     /// Create an [`Address`] from a pointer to the raw struct.
@@ -45,65 +38,95 @@ impl<'a> Address<'a> {
     /// (See the notes on [`Address::from_raw`])
     pub(crate) unsafe fn from_ptr(
         raw: *const sys::signal_protocol_address,
-    ) -> Address<'a> {
-        Address::from_raw(sys::signal_protocol_address {
-            name: (*raw).name,
-            name_len: (*raw).name_len,
-            device_id: (*raw).device_id,
-        })
-    }
-
-    pub(crate) fn raw(&self) -> *const sys::signal_protocol_address {
-        &self.raw
+    ) -> Address {
+        Address::from_raw(raw.read())
     }
 
     /// Get a string of bytes identifying a recipient (usually their name as a
     /// utf-8 string).
     ///
     /// You may also be looking for the [`Address::as_str`] method.
-    pub fn bytes(&self) -> &[u8] {
-        unsafe {
-            std::slice::from_raw_parts(
-                self.raw.name as *const u8,
-                self.raw.name_len,
-            )
-        }
-    }
+    pub fn bytes(&self) -> &[u8] { self.0.name_bytes() }
 
     /// Get the name attached to this address, converted to a `&str`.
     pub fn as_str(&self) -> Result<&str, std::str::Utf8Error> {
-        std::str::from_utf8(self.bytes())
+        self.0.name_utf8()
     }
 
     /// Get the device ID attached to this address.
+    pub fn device_id(&self) -> i32 { self.0.device_id() }
+
+    pub(crate) fn raw(&self) -> &sys::signal_protocol_address { &self.0.raw }
+}
+
+impl Debug for Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
+}
+
+struct OwnedAddress {
+    raw: sys::signal_protocol_address,
+    name: Pin<Box<[u8]>>,
+}
+
+impl OwnedAddress {
+    fn new(name: &[u8], device_id: i32) -> OwnedAddress {
+        let name = name.to_vec().into_boxed_slice();
+        let name = Pin::new(name);
+
+        OwnedAddress {
+            raw: sys::signal_protocol_address {
+                name: name.as_ptr() as *const c_char,
+                name_len: name.len(),
+                device_id,
+            },
+            name,
+        }
+    }
+
+    pub fn name_bytes(&self) -> &[u8] { &self.name }
+
+    pub fn name_utf8(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(self.name_bytes())
+    }
+
     pub fn device_id(&self) -> i32 { self.raw.device_id }
 }
 
-impl<'a> Clone for Address<'a> {
-    fn clone(&self) -> Address<'a> {
-        unsafe {
-            Address::from_raw(sys::signal_protocol_address {
-                name: self.raw.name,
-                name_len: self.raw.name_len,
-                device_id: self.raw.device_id,
-            })
-        }
-    }
-}
-
-impl<'a> Debug for Address<'a> {
+impl Debug for OwnedAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_struct("Address");
 
-        match self.as_str() {
+        match self.name_utf8() {
             Ok(name) => {
                 f.field("name", &name);
             },
             Err(_) => {
-                f.field("name", &self.bytes());
+                f.field("name", &self.name_bytes());
             },
         }
 
         f.field("device_id", &self.device_id()).finish()
+    }
+}
+
+impl Clone for OwnedAddress {
+    fn clone(&self) -> OwnedAddress {
+        OwnedAddress::new(&self.name, self.raw.device_id)
+    }
+}
+
+impl PartialEq for OwnedAddress {
+    fn eq(&self, other: &OwnedAddress) -> bool {
+        self.device_id() == other.device_id()
+            && self.name_bytes() == other.name_bytes()
+    }
+}
+
+impl Eq for OwnedAddress {}
+
+impl Hash for OwnedAddress {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        h.write_i32(self.device_id());
+        h.write(self.name_bytes());
     }
 }

--- a/libsignal-protocol/src/address.rs
+++ b/libsignal-protocol/src/address.rs
@@ -9,6 +9,7 @@ use std::{
 
 /// A reference-counted pointer to a signal address (recipient name, device ID
 /// tuple).
+#[derive(PartialEq, Eq, Hash)]
 pub struct Address(Rc<OwnedAddress>);
 
 impl Address {
@@ -61,6 +62,10 @@ impl Address {
 
 impl Debug for Address {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
+}
+
+impl Clone for Address {
+    fn clone(&self) -> Address { Address(Rc::clone(&self.0)) }
 }
 
 struct OwnedAddress {

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -246,7 +246,7 @@ pub fn create_hkdf(
 pub fn session_builder(
     ctx: &Context,
     store_context: &StoreContext,
-    address: Address<'_>,
+    address: Address,
 ) -> SessionBuilder {
     SessionBuilder::new(ctx, store_context, address)
 }

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -246,7 +246,7 @@ pub fn create_hkdf(
 pub fn session_builder(
     ctx: &Context,
     store_context: &StoreContext,
-    address: Address,
+    address: &Address,
 ) -> SessionBuilder {
     SessionBuilder::new(ctx, store_context, address)
 }

--- a/libsignal-protocol/src/identity_key_store.rs
+++ b/libsignal-protocol/src/identity_key_store.rs
@@ -21,7 +21,7 @@ pub trait IdentityKeyStore {
     /// local store is it considered 'untrusted.'
     fn is_trusted_identity(
         &self,
-        address: Address<'_>,
+        address: Address,
         identity_key: &[u8],
     ) -> Result<bool, InternalError>;
 }

--- a/libsignal-protocol/src/session_builder.rs
+++ b/libsignal-protocol/src/session_builder.rs
@@ -17,6 +17,7 @@ pub struct SessionBuilder {
     // both these fields must outlive `session_builder`
     _store_ctx: Rc<StoreContextInner>,
     _ctx: Rc<ContextInner>,
+    _addr: Address,
 }
 
 impl SessionBuilder {
@@ -24,7 +25,7 @@ impl SessionBuilder {
     pub fn new(
         ctx: &Context,
         store_context: &StoreContext,
-        address: Address,
+        address: &Address,
     ) -> SessionBuilder {
         unsafe {
             let mut raw = ptr::null_mut();
@@ -39,6 +40,7 @@ impl SessionBuilder {
                 raw,
                 _store_ctx: Rc::clone(&store_context.0),
                 _ctx: Rc::clone(&ctx.0),
+                _addr: address.clone(),
             }
         }
     }

--- a/libsignal-protocol/src/session_builder.rs
+++ b/libsignal-protocol/src/session_builder.rs
@@ -24,7 +24,7 @@ impl SessionBuilder {
     pub fn new(
         ctx: &Context,
         store_context: &StoreContext,
-        address: Address<'_>,
+        address: Address,
     ) -> SessionBuilder {
         unsafe {
             let mut raw = ptr::null_mut();

--- a/libsignal-protocol/src/session_cipher.rs
+++ b/libsignal-protocol/src/session_cipher.rs
@@ -19,6 +19,7 @@ pub struct SessionCipher {
     raw: *mut sys::session_cipher,
     _ctx: Rc<ContextInner>,
     _store_ctx: Rc<StoreContextInner>,
+    _addr: Address,
 }
 
 impl SessionCipher {
@@ -26,7 +27,7 @@ impl SessionCipher {
     pub fn new(
         ctx: &Context,
         store_ctx: &StoreContext,
-        address: Address,
+        address: &Address,
     ) -> Result<SessionCipher, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
@@ -42,6 +43,7 @@ impl SessionCipher {
                 raw,
                 _store_ctx: Rc::clone(&store_ctx.0),
                 _ctx: Rc::clone(&ctx.0),
+                _addr: address.clone(),
             })
         }
     }

--- a/libsignal-protocol/src/session_cipher.rs
+++ b/libsignal-protocol/src/session_cipher.rs
@@ -26,7 +26,7 @@ impl SessionCipher {
     pub fn new(
         ctx: &Context,
         store_ctx: &StoreContext,
-        address: Address<'_>,
+        address: Address,
     ) -> Result<SessionCipher, Error> {
         unsafe {
             let mut raw = ptr::null_mut();

--- a/libsignal-protocol/src/session_store.rs
+++ b/libsignal-protocol/src/session_store.rs
@@ -16,7 +16,7 @@ pub trait SessionStore {
     /// provided recipient [`Address`].
     fn load_session(
         &self,
-        address: Address<'_>,
+        address: Address,
     ) -> Result<Option<SerializedSession>, InternalError>;
 
     /// Get the IDs of all known devices with active sessions for a recipient.

--- a/libsignal-protocol/tests/helpers/mod.rs
+++ b/libsignal-protocol/tests/helpers/mod.rs
@@ -125,16 +125,14 @@ impl SignedPreKeyStore for BasicSignedPreKeyStore {
 
 #[derive(Default)]
 pub struct BasicSessionStore {
-    sessions: RefCell<HashMap<OwnedAddress, SerializedSession>>,
+    sessions: RefCell<HashMap<Address, SerializedSession>>,
 }
 
 impl SessionStore for BasicSessionStore {
     fn load_session(
         &self,
-        address: Address<'_>,
+        address: Address,
     ) -> Result<Option<SerializedSession>, InternalError> {
-        let address = OwnedAddress::from(address);
-
         Ok(self.sessions.borrow().get(&address).cloned())
     }
 
@@ -149,28 +147,7 @@ impl SessionStore for BasicSessionStore {
 #[derive(Debug, Default)]
 pub struct BasicIdentityKeyStore {
     registration_id: Cell<u32>,
-    trusted_identities: RefCell<Vec<(OwnedAddress, Vec<u8>)>>,
-}
-
-#[derive(Debug, Hash, PartialEq, Eq)]
-struct OwnedAddress {
-    name: Vec<u8>,
-    id: i32,
-}
-
-impl<'a> PartialEq<Address<'a>> for OwnedAddress {
-    fn eq(&self, other: &Address<'a>) -> bool {
-        self.id == other.device_id() && self.name.as_slice() == other.bytes()
-    }
-}
-
-impl<'a> From<Address<'a>> for OwnedAddress {
-    fn from(other: Address<'a>) -> OwnedAddress {
-        OwnedAddress {
-            name: other.bytes().to_vec(),
-            id: other.device_id(),
-        }
-    }
+    trusted_identities: RefCell<Vec<(Address, Vec<u8>)>>,
 }
 
 impl IdentityKeyStore for BasicIdentityKeyStore {
@@ -184,7 +161,7 @@ impl IdentityKeyStore for BasicIdentityKeyStore {
 
     fn is_trusted_identity(
         &self,
-        address: Address<'_>,
+        address: Address,
         identity_key: &[u8],
     ) -> Result<bool, InternalError> {
         let identities = self.trusted_identities.borrow();

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -273,7 +273,7 @@ fn test_basic_pre_key_v2() {
     )
     .unwrap();
     let alice_session_builder =
-        sig::session_builder(&ctx, &alice_store, bob_address);
+        sig::session_builder(&ctx, &alice_store, &bob_address);
 
     // Create Bob's data store and pre key bundle
     let bob_store = sig::store_context(


### PR DESCRIPTION
This fixes #36 by copying *all* addresses and putting them behind a reference-counted pointer, where the `name` is behind a `Pin<Box<[u8]>>` to ensure it doesn't move for the `Address`'s lifetime.

It also helps #29 by eliminating the lifetime.