### PR TITLE
[WIP] Fix openssl's `Sha256Hmac` impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ script:
   - cargo build --all --verbose
   - cargo test --all --verbose
   - cargo test --all --verbose --all-features
+  - cargo test --all --verbose --no-default-features --features="crypto-openssl"
+  - cargo test --all --verbose --no-default-features --features="crypto-native"
   - cargo doc --all --verbose
     # Check that the (non-blacklisted) examples and tests don't have memory bugs
   - python3 ./scripts/valgrind.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rental 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -551,6 +552,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rental"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rental-impl 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rental-impl"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +615,11 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -783,6 +808,8 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
+"checksum rental 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d57522f275b02e67391947c98f99d55f297fefcb6699bb000340696e63620194"
+"checksum rental-impl 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a269533a9b93bbaa4848260e51b64564cc445d46185979f31974ec703374803a"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
@@ -790,6 +817,7 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8861bc80f649f5b4c9bd38b696ae9af74499d479dbfb327f0607de6b326a36bc"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"

--- a/libsignal-protocol/Cargo.toml
+++ b/libsignal-protocol/Cargo.toml
@@ -18,18 +18,22 @@ failure_derive = "0.1.5"
 rand = "0.6.5"
 parking_lot = "0.8.0"
 lock_api = "0.2.0"
+log = "0.4.6"
+
+# -- Optional Crates -- #
 openssl = { version = "0.10", optional = true }
+rental = { version = "0.5.3", optional = true }
+
 sha2 = { version = "0.8.0", optional = true }
 hmac = { version = "0.7.0", optional = true }
 aes = { version = "0.3.2", optional = true }
 block-modes = { version = "0.3.3", optional = true }
 aes-ctr = { version = "0.3.0", optional = true }
-log = "0.4.6"
 
 [features]
 default = ["crypto-native"]
 crypto-native = ["sha2", "hmac", "aes", "block-modes", "aes-ctr"]
-crypto-openssl = ["openssl"]
+crypto-openssl = ["openssl", "rental"]
 
 [dev-dependencies]
 cfg-if = "0.1.9"

--- a/libsignal-protocol/examples/generate_keys.rs
+++ b/libsignal-protocol/examples/generate_keys.rs
@@ -31,9 +31,18 @@ use failure::Error;
 
 use sig::Context;
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "crypto-native")] {
+        type Crypto = sig::crypto::DefaultCrypto;
+    } else if #[cfg(feature = "crypto-openssl")] {
+        type Crypto = sig::crypto::OpenSSLCrypto;
+    } else {
+        compile_error!("These tests require one of the crypto features to be enabled");
+    }
+}
 fn main() -> Result<(), Error> {
     env_logger::init();
-    let ctx = Context::default();
+    let ctx = Context::new(Crypto::default()).unwrap();
 
     let extended_range = 0;
     let start = 123;

--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -45,23 +45,34 @@
 
 extern crate libsignal_protocol as sig;
 
-#[path = "../tests/helpers/mod.rs"]
-mod helpers;
+use std::time::SystemTime;
 
 use failure::{Error, ResultExt};
+
 use sig::{
+    Address,
+    Context, PreKeyBundle, Serializable, SessionBuilder, SessionCipher,
     stores::{
         InMemoryIdentityKeyStore, InMemoryPreKeyStore, InMemorySessionStore,
         InMemorySignedPreKeyStore,
     },
-    Address, Context, PreKeyBundle, Serializable, SessionBuilder,
-    SessionCipher,
 };
-use std::time::SystemTime;
 
+#[path = "../tests/helpers/mod.rs"]
+mod helpers;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "crypto-native")] {
+        type Crypto = sig::crypto::DefaultCrypto;
+    } else if #[cfg(feature = "crypto-openssl")] {
+        type Crypto = sig::crypto::OpenSSLCrypto;
+    } else {
+        compile_error!("These tests require one of the crypto features to be enabled");
+    }
+}
 fn main() -> Result<(), Error> {
     env_logger::init();
-    let ctx = Context::default();
+    let ctx = Context::new(Crypto::default()).unwrap();
 
     // first we'll need a copy of bob's public key and some of his pre-keys
     let bob_address = Address::new("+14159998888", 1);

--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -50,12 +50,12 @@ use std::time::SystemTime;
 use failure::{Error, ResultExt};
 
 use sig::{
-    Address,
-    Context, PreKeyBundle, Serializable, SessionBuilder, SessionCipher,
     stores::{
         InMemoryIdentityKeyStore, InMemoryPreKeyStore, InMemorySessionStore,
         InMemorySignedPreKeyStore,
     },
+    Address, Context, PreKeyBundle, Serializable, SessionBuilder,
+    SessionCipher,
 };
 
 #[path = "../tests/helpers/mod.rs"]

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -32,8 +32,6 @@ use crate::{
 };
 #[cfg(feature = "crypto-native")]
 use crate::crypto::DefaultCrypto;
-#[cfg(feature = "crypto-openssl")]
-use crate::crypto::OpenSSLCrypto;
 // for rustdoc link resolution
 #[allow(unused_imports)]
 use crate::keys::{PreKey, PublicKey};
@@ -76,8 +74,19 @@ pub fn generate_key_pair(ctx: &Context) -> Result<KeyPair, Error> {
 /// ```rust
 /// # use libsignal_protocol::{keys::PublicKey, Context};
 /// # use failure::Error;
+/// # use cfg_if::cfg_if;
 /// # fn main() -> Result<(), Error> {
-/// let ctx = Context::default();
+/// # cfg_if::cfg_if! {
+/// #  if #[cfg(feature = "crypto-native")] {
+/// #      type Crypto = libsignal_protocol::crypto::DefaultCrypto;
+/// #  } else if #[cfg(feature = "crypto-openssl")] {
+/// #      type Crypto = libsignal_protocol::crypto::OpenSSLCrypto;
+/// #  } else {
+/// #      compile_error!("These tests require one of the crypto features to be enabled");
+/// #  }
+/// # }
+/// // the `Crypto` here is a type alias to one of `OpenSSLCrypto` or `DefaultCrypto`.
+/// let ctx = Context::new(Crypto::default()).unwrap();
 /// let key_pair = libsignal_protocol::generate_key_pair(&ctx)?;
 ///
 /// let msg = "Hello, World!";
@@ -289,7 +298,6 @@ impl Default for Context {
     }
 }
 
-
 /// Our Rust wrapper around the [`sys::signal_context`].
 ///
 /// # Safety
@@ -439,6 +447,7 @@ mod tests {
     #[cfg(feature = "crypto-openssl")]
     #[test]
     fn library_initialization_example_from_readme_openssl() {
+        use crate::crypto::OpenSSLCrypto;
         let ctx = Context::new(OpenSSLCrypto::default()).unwrap();
 
         drop(ctx);

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -13,9 +13,9 @@ use lock_api::RawMutex as _;
 use log::Level;
 use parking_lot::RawMutex;
 
+#[cfg(feature = "crypto-native")]
+use crate::crypto::DefaultCrypto;
 use crate::{
-    Address,
-    Buffer,
     crypto::{Crypto, CryptoProvider},
     errors::{FromInternalErrorCode, InternalError},
     hkdf::HMACBasedKeyDerivationFunction,
@@ -23,15 +23,15 @@ use crate::{
         IdentityKeyPair, KeyPair, PreKeyList, PrivateKey, SessionSignedPreKey,
     },
     raw_ptr::Raw,
-    session_builder::SessionBuilder, StoreContext, stores::{
+    session_builder::SessionBuilder,
+    stores::{
         identity_key_store::{self as iks, IdentityKeyStore},
         pre_key_store::{self as pks, PreKeyStore},
         session_store::{self as sess, SessionStore},
         signed_pre_key_store::{self as spks, SignedPreKeyStore},
     },
+    Address, Buffer, StoreContext,
 };
-#[cfg(feature = "crypto-native")]
-use crate::crypto::DefaultCrypto;
 // for rustdoc link resolution
 #[allow(unused_imports)]
 use crate::keys::{PreKey, PublicKey};

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -289,17 +289,6 @@ impl Default for Context {
     }
 }
 
-#[cfg(feature = "crypto-openssl")]
-impl Default for Context {
-    fn default() -> Context {
-        match Context::new(OpenSSLCrypto::default()) {
-            Ok(c) => c,
-            Err(e) => {
-                panic!("Unable to create a context using the defaults: {}", e)
-            },
-        }
-    }
-}
 
 /// Our Rust wrapper around the [`sys::signal_context`].
 ///
@@ -439,9 +428,18 @@ struct State {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "crypto-native")]
     #[test]
-    fn library_initialization_example_from_readme() {
+    fn library_initialization_example_from_readme_native() {
         let ctx = Context::default();
+
+        drop(ctx);
+    }
+
+    #[cfg(feature = "crypto-openssl")]
+    #[test]
+    fn library_initialization_example_from_readme_openssl() {
+        let ctx = Context::new(OpenSSLCrypto::default()).unwrap();
 
         drop(ctx);
     }

--- a/libsignal-protocol/src/crypto/openssl.rs
+++ b/libsignal-protocol/src/crypto/openssl.rs
@@ -88,7 +88,7 @@ impl Crypto for OpenSSLCrypto {
         let hmac_signer = hmac::HmacSigner::try_new(pkey, |pkey| {
             Signer::new(MessageDigest::sha256(), pkey)
         })
-            .map_err(|_e| InternalError::Unknown)?;
+        .map_err(|_e| InternalError::Unknown)?;
         Ok(Box::new(hmac_signer))
     }
 

--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -1,12 +1,14 @@
-use crate::{
-    errors::{FromInternalErrorCode, InternalError},
-    raw_ptr::Raw,
-    Context,
-};
-use failure::Error;
 use std::{
     cmp::{Ord, Ordering},
     ptr,
+};
+
+use failure::Error;
+
+use crate::{
+    Context,
+    errors::{FromInternalErrorCode, InternalError},
+    raw_ptr::Raw,
 };
 
 /// The public part of an elliptic curve key pair.
@@ -103,7 +105,16 @@ mod tests {
 
     #[test]
     fn decode_from_binary() {
-        let ctx = Context::default();
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "crypto-native")] {
+                type Crypto = crate::crypto::DefaultCrypto;
+            } else if #[cfg(feature = "crypto-openssl")] {
+                type Crypto = crate::crypto::OpenSSLCrypto;
+            } else {
+                compile_error!("These tests require one of the crypto features to be enabled");
+            }
+        }
+        let ctx = Context::new(Crypto::default()).unwrap();
         let public = &[
             0x05, 0x1b, 0xb7, 0x59, 0x66, 0xf2, 0xe9, 0x3a, 0x36, 0x91, 0xdf,
             0xff, 0x94, 0x2b, 0xb2, 0xa4, 0x66, 0xa1, 0xc0, 0x8b, 0x8d, 0x78,

--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -6,9 +6,9 @@ use std::{
 use failure::Error;
 
 use crate::{
+    Context,
     errors::{FromInternalErrorCode, InternalError},
     raw_ptr::Raw,
-    Context,
 };
 
 /// The public part of an elliptic curve key pair.
@@ -103,6 +103,7 @@ impl_serializable!(PublicKey, ec_public_key_serialize, asd);
 mod tests {
     use super::*;
 
+    #[cfg(any(feature = "crypto-native", feature = "crypto-openssl"))]
     #[test]
     fn decode_from_binary() {
         cfg_if::cfg_if! {

--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -6,9 +6,9 @@ use std::{
 use failure::Error;
 
 use crate::{
-    Context,
     errors::{FromInternalErrorCode, InternalError},
     raw_ptr::Raw,
+    Context,
 };
 
 /// The public part of an elliptic curve key pair.

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -65,12 +65,13 @@
 // we use the *-sys crate everywhere so give it a shorter name
 #[allow(unused_extern_crates)]
 extern crate libsignal_protocol_sys as sys;
+#[cfg(feature = "crypto-openssl")]
+#[macro_use]
+extern crate rental;
 
-// so rustdoc can resolve links
-#[allow(unused_imports)]
-use crate::stores::{
-    IdentityKeyStore, PreKeyStore, SessionStore, SignedPreKeyStore,
-};
+use std::io::Write;
+
+use failure::Error;
 
 pub use crate::{
     address::Address,
@@ -84,6 +85,14 @@ pub use crate::{
     session_record::SessionRecord,
     session_state::SessionState,
     store_context::StoreContext,
+};
+// bring into scope for rustdoc
+#[allow(unused_imports)]
+use crate::messages::PreKeySignalMessage;
+// so rustdoc can resolve links
+#[allow(unused_imports)]
+use crate::stores::{
+    IdentityKeyStore, PreKeyStore, SessionStore, SignedPreKeyStore,
 };
 
 #[macro_use]
@@ -105,13 +114,6 @@ mod session_record;
 mod session_state;
 mod store_context;
 pub mod stores;
-
-use failure::Error;
-use std::io::Write;
-
-// bring into scope for rustdoc
-#[allow(unused_imports)]
-use crate::messages::PreKeySignalMessage;
 
 /// A helper trait for something which can be serialized to protobufs.
 pub trait Serializable {

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -1,20 +1,23 @@
 extern crate libsignal_protocol as sig;
-mod helpers;
 
-use crate::helpers::{fake_random_generator, MockCrypto};
-use sig::{
-    keys::{PrivateKey, PublicKey},
-    messages::PreKeySignalMessage,
-    stores::{
-        InMemoryIdentityKeyStore, InMemoryPreKeyStore, InMemorySessionStore,
-        InMemorySignedPreKeyStore,
-    },
-    Address, Context, InternalError, PreKeyBundle, Serializable,
-};
 use std::{
     convert::TryFrom,
     time::{Duration, SystemTime},
 };
+
+use sig::{
+    Address,
+    Context,
+    InternalError,
+    keys::{PrivateKey, PublicKey}, messages::PreKeySignalMessage, PreKeyBundle, Serializable, stores::{
+        InMemoryIdentityKeyStore, InMemoryPreKeyStore, InMemorySessionStore,
+        InMemorySignedPreKeyStore,
+    },
+};
+
+use crate::helpers::{fake_random_generator, MockCrypto};
+
+mod helpers;
 
 fn mock_ctx() -> Context {
     cfg_if::cfg_if! {
@@ -45,7 +48,7 @@ fn test_curve25519_generate_public() {
         0x94, 0x2b, 0xb2, 0xa4, 0x66, 0xa1, 0xc0, 0x8b, 0x8d, 0x78, 0xca, 0x3f,
         0x4d, 0x6d, 0xf8, 0xb8, 0xbf, 0xa2, 0xe4, 0xee, 0x28,
     ];
-    let ctx = Context::default();
+    let ctx = mock_ctx();
 
     let alice_private_key =
         PrivateKey::decode_point(&ctx, ALICE_PRIVATE).unwrap();
@@ -170,7 +173,7 @@ fn test_generate_identity_key_pair() {
 
 #[test]
 fn test_curve25519_large_signatures() {
-    let ctx = Context::default();
+    let ctx = mock_ctx();
     let pair = sig::generate_key_pair(&ctx).unwrap();
 
     let mut msg = vec![0; 1048576];

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -6,13 +6,13 @@ use std::{
 };
 
 use sig::{
-    Address,
-    Context,
-    InternalError,
-    keys::{PrivateKey, PublicKey}, messages::PreKeySignalMessage, PreKeyBundle, Serializable, stores::{
+    keys::{PrivateKey, PublicKey},
+    messages::PreKeySignalMessage,
+    stores::{
         InMemoryIdentityKeyStore, InMemoryPreKeyStore, InMemorySessionStore,
         InMemorySignedPreKeyStore,
     },
+    Address, Context, InternalError, PreKeyBundle, Serializable,
 };
 
 use crate::helpers::{fake_random_generator, MockCrypto};


### PR DESCRIPTION
Turns out that we are using the wrong implementation from `openssl` crate.
and the proper way to do this is using a [`Signer`](https://docs.rs/openssl/0.10.23/openssl/sign/struct.Signer.html) along with [`PKey`](https://docs.rs/openssl/0.10.23/openssl/pkey/struct.PKey.html).

The problem is that the `Signer` takes the `Pkey` by ref as a [`PKeyRef`](https://docs.rs/openssl/0.10.23/openssl/pkey/struct.PKeyRef.html) which is very annoying, since i cannot return the `signer` from the function, because it has a ref to the local `pkey`.
<details><summary>Error Message from `cargo check`</summary>
<p>

```bash
$ cargo check
```
```rust
error[E0515]: cannot return value referencing local variable `pkey`
  --> libsignal-protocol/src/crypto/openssl.rs:85:9
   |
82 |         let signer = Signer::new(MessageDigest::sha256(), &pkey)
   |                                                           ----- `pkey` is borrowed here
...
85 |         Ok(Box::new(signer))
   |         ^^^^^^^^^^^^^^^^^^^^ returns a value referencing data owned by the current function

```
</p>
</details>
it's of course a problem related to `lifetimes` since `Signer` has an internal lifetime for the underlying binding to the `openssl` library. 

@Michael-F-Bryan can you help on solving this problem ?