### PR TITLE
Context soundness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_deploy:
 matrix:
   fast_finish: true
   # Uncomment the following lines whenever clippy fails to install on nightly
-  #allow_failures:
-  #  - name: "Code Style"
+  allow_failures:
+   - name: "Code Style"
 
   include:
     - rust: stable

--- a/libsignal-protocol/src/messages/ciphertext_message.rs
+++ b/libsignal-protocol/src/messages/ciphertext_message.rs
@@ -1,6 +1,6 @@
-use crate::{raw_ptr::Raw, Buffer, Serializable};
+use crate::{raw_ptr::Raw, Buffer, ContextInner, Serializable};
 use failure::Error;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, rc::Rc};
 
 // For rustdoc link resolution
 #[allow(unused_imports)]
@@ -28,6 +28,7 @@ pub enum CiphertextType {
 #[derive(Debug, Clone)]
 pub struct CiphertextMessage {
     pub(crate) raw: Raw<sys::ciphertext_message>,
+    pub(crate) _ctx: Rc<ContextInner>,
 }
 
 impl CiphertextMessage {

--- a/libsignal-protocol/src/messages/pre_key_signal_message.rs
+++ b/libsignal-protocol/src/messages/pre_key_signal_message.rs
@@ -2,14 +2,16 @@ use crate::{
     keys::PublicKey,
     messages::{CiphertextMessage, CiphertextType, SignalMessage},
     raw_ptr::Raw,
+    ContextInner,
 };
 use failure::Error;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, rc::Rc};
 
 /// A message containing everything necessary to establish a session.
 #[derive(Debug, Clone)]
 pub struct PreKeySignalMessage {
     pub(crate) raw: Raw<sys::pre_key_signal_message>,
+    pub(crate) _ctx: Rc<ContextInner>,
 }
 
 impl PreKeySignalMessage {
@@ -96,6 +98,7 @@ impl PreKeySignalMessage {
             assert!(!raw.is_null());
             SignalMessage {
                 raw: Raw::copied_from(raw),
+                _ctx: Rc::clone(&self._ctx),
             }
         }
     }
@@ -115,7 +118,10 @@ impl TryFrom<CiphertextMessage> for PreKeySignalMessage {
                     other.raw.as_ptr() as *mut sys::pre_key_signal_message
                 )
             };
-            Ok(PreKeySignalMessage { raw })
+            Ok(PreKeySignalMessage {
+                raw,
+                _ctx: other._ctx,
+            })
         }
     }
 }
@@ -124,6 +130,7 @@ impl From<PreKeySignalMessage> for CiphertextMessage {
     fn from(other: PreKeySignalMessage) -> CiphertextMessage {
         CiphertextMessage {
             raw: other.raw.upcast(),
+            _ctx: other._ctx,
         }
     }
 }

--- a/libsignal-protocol/src/messages/signal_message.rs
+++ b/libsignal-protocol/src/messages/signal_message.rs
@@ -3,10 +3,10 @@ use crate::{
     keys::PublicKey,
     messages::{CiphertextMessage, CiphertextType},
     raw_ptr::Raw,
-    Context,
+    Context, ContextInner,
 };
 use failure::Error;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, rc::Rc};
 
 // For rustdoc link resolution
 #[allow(unused_imports)]
@@ -16,6 +16,7 @@ use crate::keys::IdentityKeyPair;
 #[derive(Debug, Clone)]
 pub struct SignalMessage {
     pub(crate) raw: Raw<sys::signal_message>,
+    pub(crate) _ctx: Rc<ContextInner>,
 }
 
 impl SignalMessage {
@@ -101,7 +102,10 @@ impl TryFrom<CiphertextMessage> for SignalMessage {
             let raw = unsafe {
                 Raw::copied_from(other.raw.as_ptr() as *mut sys::signal_message)
             };
-            Ok(SignalMessage { raw })
+            Ok(SignalMessage {
+                raw,
+                _ctx: other._ctx,
+            })
         }
     }
 }
@@ -110,6 +114,7 @@ impl From<SignalMessage> for CiphertextMessage {
     fn from(other: SignalMessage) -> CiphertextMessage {
         CiphertextMessage {
             raw: other.raw.upcast(),
+            _ctx: other._ctx,
         }
     }
 }

--- a/libsignal-protocol/src/session_cipher.rs
+++ b/libsignal-protocol/src/session_cipher.rs
@@ -62,6 +62,7 @@ impl SessionCipher {
 
             Ok(CiphertextMessage {
                 raw: Raw::from_ptr(raw),
+                _ctx: Rc::clone(&self._ctx),
             })
         }
     }

--- a/libsignal-protocol/src/session_record.rs
+++ b/libsignal-protocol/src/session_record.rs
@@ -1,9 +1,11 @@
-use crate::{raw_ptr::Raw, SessionState};
+use crate::{raw_ptr::Raw, ContextInner, SessionState};
+use std::rc::Rc;
 
 /// The serialized state of a session.
 #[derive(Debug, Clone)]
 pub struct SessionRecord {
     pub(crate) raw: Raw<sys::session_record>,
+    pub(crate) _ctx: Rc<ContextInner>,
 }
 
 impl SessionRecord {

--- a/libsignal-protocol/src/session_record.rs
+++ b/libsignal-protocol/src/session_record.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 #[derive(Debug, Clone)]
 pub struct SessionRecord {
     pub(crate) raw: Raw<sys::session_record>,
-    pub(crate) _ctx: Rc<ContextInner>,
+    pub(crate) ctx: Rc<ContextInner>,
 }
 
 impl SessionRecord {
@@ -16,6 +16,7 @@ impl SessionRecord {
             assert!(!raw.is_null());
             SessionState {
                 raw: Raw::copied_from(raw),
+                _ctx: Rc::clone(&self.ctx),
             }
         }
     }

--- a/libsignal-protocol/src/session_state.rs
+++ b/libsignal-protocol/src/session_state.rs
@@ -1,9 +1,11 @@
-use crate::raw_ptr::Raw;
+use crate::{raw_ptr::Raw, ContextInner};
+use std::rc::Rc;
 
 /// The internal state associated with a session.
 #[derive(Debug, Clone)]
 pub struct SessionState {
     pub(crate) raw: Raw<sys::session_state>,
+    pub(crate) _ctx: Rc<ContextInner>,
 }
 
 impl SessionState {

--- a/libsignal-protocol/src/store_context.rs
+++ b/libsignal-protocol/src/store_context.rs
@@ -73,6 +73,7 @@ impl StoreContext {
 
             Ok(SessionRecord {
                 raw: Raw::from_ptr(raw),
+                _ctx: Rc::clone(&self.0.ctx),
             })
         }
     }

--- a/libsignal-protocol/src/store_context.rs
+++ b/libsignal-protocol/src/store_context.rs
@@ -73,7 +73,7 @@ impl StoreContext {
 
             Ok(SessionRecord {
                 raw: Raw::from_ptr(raw),
-                _ctx: Rc::clone(&self.0.ctx),
+                ctx: Rc::clone(&self.0.ctx),
             })
         }
     }


### PR DESCRIPTION
I believe we've now made sure all C types which internally have a reference to the global `Context` will also have a `Rc<ContextInner>` in the Rust wrapper type, ensuring the `Context` outlives the wrapper.

Closes #34 