### PR TITLE
Exception safety

### DIFF
--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -397,8 +397,8 @@ unsafe extern "C" fn log_trampoline(
     len: usize,
     user_data: *mut c_void,
 ) {
-    signal_assert!(!msg.is_null());
-    signal_assert!(!user_data.is_null());
+    signal_assert!(!msg.is_null(), ());
+    signal_assert!(!user_data.is_null(), ());
 
     let state = &*(user_data as *const State);
     let buffer = std::slice::from_raw_parts(msg as *const u8, len);

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -386,8 +386,8 @@ unsafe extern "C" fn log_trampoline(
     len: usize,
     user_data: *mut c_void,
 ) {
-    assert!(!msg.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!msg.is_null());
+    signal_assert!(!user_data.is_null());
 
     let state = &*(user_data as *const State);
     let buffer = std::slice::from_raw_parts(msg as *const u8, len);

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -2,9 +2,11 @@ use std::{
     convert::TryFrom,
     fmt::{self, Debug, Formatter},
     os::raw::{c_char, c_int, c_void},
+    panic::RefUnwindSafe,
     pin::Pin,
     ptr,
     rc::Rc,
+    sync::Mutex,
     time::SystemTime,
 };
 
@@ -284,6 +286,15 @@ impl Context {
     pub fn crypto(&self) -> &dyn Crypto { self.0.crypto.state() }
 
     pub(crate) fn raw(&self) -> *mut sys::signal_context { self.0.raw() }
+
+    /// Se the function to use when `libsignal-protocol-c` emits a log message.
+    pub fn set_log_func<F>(&self, log_func: F)
+    where
+        F: Fn(Level, &str) + RefUnwindSafe + 'static,
+    {
+        let mut lf = self.0.state.log_func.lock().unwrap();
+        *lf = Box::new(log_func);
+    }
 }
 
 #[cfg(feature = "crypto-native")]
@@ -323,7 +334,7 @@ impl ContextInner {
             let crypto = CryptoProvider::new(crypto);
             let mut state = Pin::new(Box::new(State {
                 mux: RawMutex::INIT,
-                log_func: Box::new(default_log_func),
+                log_func: Mutex::new(Box::new(default_log_func)),
             }));
 
             let user_data =
@@ -394,7 +405,12 @@ unsafe extern "C" fn log_trampoline(
     let level = translate_log_level(level);
 
     if let Ok(message) = std::str::from_utf8(buffer) {
-        (state.log_func)(level, message);
+        // we can't log the errors that occur while logging errors, so just
+        // drop them on the floor...
+        let _ = std::panic::catch_unwind(|| {
+            let log_func = state.log_func.lock().unwrap();
+            log_func(level, message);
+        });
     }
 }
 
@@ -429,7 +445,7 @@ unsafe extern "C" fn unlock_function(user_data: *mut c_void) {
 /// appropriate synchronisation mechanisms (i.e. `RefCell` or atomics).
 struct State {
     mux: RawMutex,
-    log_func: Box<dyn Fn(Level, &str)>,
+    log_func: Mutex<Box<dyn Fn(Level, &str) + RefUnwindSafe>>,
 }
 
 #[cfg(test)]

--- a/libsignal-protocol/src/crypto/mod.rs
+++ b/libsignal-protocol/src/crypto/mod.rs
@@ -1,7 +1,6 @@
 //! Underlying cryptographic routines.
 
 use std::{
-    cell::RefCell,
     convert::TryFrom,
     os::raw::{c_int, c_void},
     panic::RefUnwindSafe,
@@ -388,6 +387,7 @@ unsafe extern "C" fn decrypt_func(
     )
 }
 
+#[allow(clippy::cognitive_complexity)]
 unsafe extern "C" fn internal_cipher(
     mode: CipherMode,
     output: *mut *mut signal_buffer,

--- a/libsignal-protocol/src/crypto/mod.rs
+++ b/libsignal-protocol/src/crypto/mod.rs
@@ -158,8 +158,8 @@ unsafe extern "C" fn random_func(
     len: usize,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!data.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!data.is_null());
+    signal_assert!(!user_data.is_null());
 
     let user_data = &*(user_data as *const State);
     let buffer = slice::from_raw_parts_mut(data, len);
@@ -185,8 +185,8 @@ unsafe extern "C" fn hmac_sha256_final_func(
     _user_data: *mut c_void,
 ) -> i32 {
     // just to make sure that the c ffi gave us a valid buffer to write to.
-    assert!(!output.is_null());
-    assert!(!hmac_context.is_null());
+    signal_assert!(!output.is_null());
+    signal_assert!(!hmac_context.is_null());
 
     let hmac_context = &*(hmac_context as *const HmacContext);
 
@@ -206,8 +206,8 @@ unsafe extern "C" fn hmac_sha256_init_func(
     key_len: usize,
     user_data: *mut c_void,
 ) -> i32 {
-    assert!(!key.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!key.is_null());
+    signal_assert!(!user_data.is_null());
 
     let state = &*(user_data as *const State);
     let key = slice::from_raw_parts(key, key_len);
@@ -231,8 +231,8 @@ unsafe extern "C" fn hmac_sha256_update_func(
     data_len: usize,
     _user_data: *mut c_void,
 ) -> i32 {
-    assert!(!data.is_null());
-    assert!(!hmac_context.is_null());
+    signal_assert!(!data.is_null());
+    signal_assert!(!hmac_context.is_null());
 
     let hmac_context = &*(hmac_context as *const HmacContext);
 
@@ -244,7 +244,7 @@ unsafe extern "C" fn sha512_digest_init_func(
     digest_context: *mut *mut c_void,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
+    signal_assert!(!user_data.is_null());
 
     let user_data = &*(user_data as *const State);
     let hasher = match user_data.0.sha512_digest() {
@@ -267,8 +267,8 @@ unsafe extern "C" fn sha512_digest_update_func(
     data_len: usize,
     _user_data: *mut c_void,
 ) -> c_int {
-    assert!(!data.is_null());
-    assert!(!digest_context.is_null());
+    signal_assert!(!data.is_null());
+    signal_assert!(!digest_context.is_null());
 
     let hasher = &*(digest_context as *const DigestContext);
     let mut hasher = hasher.0.borrow_mut();
@@ -283,8 +283,8 @@ unsafe extern "C" fn sha512_digest_final_func(
     _user_data: *mut c_void,
 ) -> c_int {
     // just to make sure that the c ffi gave us a valid buffer to write to.
-    assert!(!output.is_null());
-    assert!(!digest_context.is_null());
+    signal_assert!(!output.is_null());
+    signal_assert!(!digest_context.is_null());
 
     let hasher = &*(digest_context as *const DigestContext);
 
@@ -375,11 +375,11 @@ unsafe extern "C" fn internal_cipher(
 ) -> c_int {
     use self::CipherMode::*;
     // just to make sure that the c ffi gave us a valid buffer to write to.
-    assert!(!output.is_null());
-    assert!(!user_data.is_null());
-    assert!(!key.is_null());
-    assert!(!iv.is_null());
-    assert!(!data.is_null());
+    signal_assert!(!output.is_null());
+    signal_assert!(!user_data.is_null());
+    signal_assert!(!key.is_null());
+    signal_assert!(!iv.is_null());
+    signal_assert!(!data.is_null());
 
     let signal_cipher_type = match SignalCipherType::try_from(cipher) {
         Ok(ty) => ty,

--- a/libsignal-protocol/src/crypto/mod.rs
+++ b/libsignal-protocol/src/crypto/mod.rs
@@ -4,8 +4,10 @@ use std::{
     cell::RefCell,
     convert::TryFrom,
     os::raw::{c_int, c_void},
+    panic::RefUnwindSafe,
     pin::Pin,
     ptr, slice,
+    sync::Mutex,
 };
 
 use sys::{signal_buffer, signal_crypto_provider};
@@ -82,7 +84,7 @@ pub trait Sha512Digest {
 }
 
 /// Cryptography routines used in the signal protocol.
-pub trait Crypto {
+pub trait Crypto: RefUnwindSafe {
     /// Fill the provided buffer with some random bytes.
     fn fill_random(&self, buffer: &mut [u8]) -> Result<(), InternalError>;
 
@@ -149,9 +151,9 @@ impl CryptoProvider {
 
 struct State(Box<dyn Crypto>);
 
-struct HmacContext(RefCell<Box<dyn Sha256Hmac>>);
+struct HmacContext(Mutex<Box<dyn Sha256Hmac>>);
 
-struct DigestContext(RefCell<Box<dyn Sha512Digest>>);
+struct DigestContext(Mutex<Box<dyn Sha512Digest>>);
 
 unsafe extern "C" fn random_func(
     data: *mut u8,
@@ -162,8 +164,32 @@ unsafe extern "C" fn random_func(
     signal_assert!(!user_data.is_null());
 
     let user_data = &*(user_data as *const State);
-    let buffer = slice::from_raw_parts_mut(data, len);
-    user_data.0.fill_random(buffer).into_code()
+
+    let panic_result = std::panic::catch_unwind(|| {
+        let buffer = slice::from_raw_parts_mut(data, len);
+        user_data.0.fill_random(buffer)
+    });
+
+    match panic_result {
+        Ok(Ok(_)) => sys::SG_SUCCESS as c_int,
+        Ok(Err(e)) => {
+            log::error!("Unable to generate random data: {}", e);
+            InternalError::Unknown.code()
+        },
+        Err(e) => {
+            let msg = if let Some(m) = e.downcast_ref::<&str>() {
+                m
+            } else if let Some(m) = e.downcast_ref::<String>() {
+                m.as_str()
+            } else {
+                "Unknown panic"
+            };
+            log::error!("Panic encountered while trying to generate {} random bytes at {}#{}: {}",
+            len, file!(), line!(), msg);
+
+            InternalError::Unknown.code()
+        },
+    }
 }
 
 unsafe extern "C" fn hmac_sha256_cleanup_func(
@@ -190,7 +216,7 @@ unsafe extern "C" fn hmac_sha256_final_func(
 
     let hmac_context = &*(hmac_context as *const HmacContext);
 
-    match hmac_context.0.borrow_mut().finalize() {
+    match signal_catch_unwind!(hmac_context.0.lock().unwrap().finalize()) {
         Ok(hmac) => {
             let buffer = Buffer::from(hmac);
             *output = buffer.into_raw();
@@ -212,7 +238,7 @@ unsafe extern "C" fn hmac_sha256_init_func(
     let state = &*(user_data as *const State);
     let key = slice::from_raw_parts(key, key_len);
 
-    let hasher = match state.0.hmac_sha256(key) {
+    let hasher = match signal_catch_unwind!(state.0.hmac_sha256(key)) {
         Ok(h) => h,
         Err(e) => {
             *hmac_context = ptr::null_mut();
@@ -220,8 +246,8 @@ unsafe extern "C" fn hmac_sha256_init_func(
         },
     };
 
-    *hmac_context = Box::into_raw(Box::new(HmacContext(RefCell::new(hasher))))
-        as *mut c_void;
+    *hmac_context =
+        Box::into_raw(Box::new(HmacContext(Mutex::new(hasher)))) as *mut c_void;
     sys::SG_SUCCESS as c_int
 }
 
@@ -237,7 +263,9 @@ unsafe extern "C" fn hmac_sha256_update_func(
     let hmac_context = &*(hmac_context as *const HmacContext);
 
     let data = slice::from_raw_parts(data, data_len);
-    hmac_context.0.borrow_mut().update(data).into_code()
+
+    signal_catch_unwind!(hmac_context.0.lock().unwrap().update(data))
+        .into_code()
 }
 
 unsafe extern "C" fn sha512_digest_init_func(
@@ -247,7 +275,7 @@ unsafe extern "C" fn sha512_digest_init_func(
     signal_assert!(!user_data.is_null());
 
     let user_data = &*(user_data as *const State);
-    let hasher = match user_data.0.sha512_digest() {
+    let hasher = match signal_catch_unwind!(user_data.0.sha512_digest()) {
         Ok(h) => h,
         Err(e) => {
             *digest_context = ptr::null_mut();
@@ -255,7 +283,7 @@ unsafe extern "C" fn sha512_digest_init_func(
         },
     };
 
-    let dc = Box::new(DigestContext(RefCell::new(hasher)));
+    let dc = Box::new(DigestContext(Mutex::new(hasher)));
     *digest_context = Box::into_raw(Box::new(dc)) as *mut c_void;
 
     sys::SG_SUCCESS as c_int
@@ -271,10 +299,9 @@ unsafe extern "C" fn sha512_digest_update_func(
     signal_assert!(!digest_context.is_null());
 
     let hasher = &*(digest_context as *const DigestContext);
-    let mut hasher = hasher.0.borrow_mut();
 
     let buffer = slice::from_raw_parts(data, data_len);
-    hasher.update(buffer).into_code()
+    signal_catch_unwind!(hasher.0.lock().unwrap().update(buffer)).into_code()
 }
 
 unsafe extern "C" fn sha512_digest_final_func(
@@ -288,7 +315,7 @@ unsafe extern "C" fn sha512_digest_final_func(
 
     let hasher = &*(digest_context as *const DigestContext);
 
-    match hasher.0.borrow_mut().finalize() {
+    match signal_catch_unwind!(hasher.0.lock().unwrap().finalize()) {
         Ok(buf) => {
             let buffer = Buffer::from(buf);
             *output = buffer.into_raw();
@@ -394,8 +421,18 @@ unsafe extern "C" fn internal_cipher(
     let user_data = &*(user_data as *const State);
 
     let result = match mode {
-        Encrypt => user_data.0.encrypt(signal_cipher_type, key, iv, data),
-        Decrypt => user_data.0.decrypt(signal_cipher_type, key, iv, data),
+        Encrypt => signal_catch_unwind!(user_data.0.encrypt(
+            signal_cipher_type,
+            key,
+            iv,
+            data
+        )),
+        Decrypt => signal_catch_unwind!(user_data.0.decrypt(
+            signal_cipher_type,
+            key,
+            iv,
+            data
+        )),
     };
 
     match result {

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -132,6 +132,10 @@ impl<T> IntoInternalErrorCode for Result<T, InternalError> {
     }
 }
 
+impl From<InternalError> for i32 {
+    fn from(other: InternalError) -> i32 { other.code() }
+}
+
 impl Display for InternalError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {

--- a/libsignal-protocol/src/macros.rs
+++ b/libsignal-protocol/src/macros.rs
@@ -37,3 +37,20 @@ macro_rules! impl_is_a {
         )*
     };
 }
+
+macro_rules! signal_assert {
+    ($condition:expr $(, $tok:tt)*) => {
+        if !$condition {
+            ::log::error!(
+                "Assertion failed at {}#{}: {}",
+                file!(),
+                line!(),
+                stringify!($condition),
+                $(
+                    ,$tok
+                )*
+            );
+            ::log::error!("{}", ::failure::Backtrace::new());
+        }
+    };
+}

--- a/libsignal-protocol/src/macros.rs
+++ b/libsignal-protocol/src/macros.rs
@@ -38,19 +38,25 @@ macro_rules! impl_is_a {
     };
 }
 
+/// An an alternative to [`assert!()`] for functions called from C.
 macro_rules! signal_assert {
-    ($condition:expr $(, $tok:tt)*) => {
+    ($condition:expr) => {
         if !$condition {
             ::log::error!(
                 "Assertion failed at {}#{}: {}",
                 file!(),
                 line!(),
                 stringify!($condition),
-                $(
-                    ,$tok
-                )*
             );
             ::log::error!("{}", ::failure::Backtrace::new());
+
+            eprintln!(
+                "Aborting because the application reached an unexpected state at {}#{}: {}",
+                file!(),
+                line!(),
+                stringify!($condition)
+            );
+            ::std::process::exit(1);
         }
     };
 }

--- a/libsignal-protocol/src/macros.rs
+++ b/libsignal-protocol/src/macros.rs
@@ -41,6 +41,9 @@ macro_rules! impl_is_a {
 /// An an alternative to [`assert!()`] for functions called from C.
 macro_rules! signal_assert {
     ($condition:expr) => {
+        signal_assert!($condition, $crate::InternalError::InvalidArgument);
+    };
+    ($condition:expr, $ret:expr) => {
         if !$condition {
             ::log::error!(
                 "Assertion failed at {}#{}: {}",
@@ -56,7 +59,7 @@ macro_rules! signal_assert {
                 line!(),
                 stringify!($condition)
             );
-            ::std::process::exit(1);
+            return $ret.into();
         }
     };
 }

--- a/libsignal-protocol/src/macros.rs
+++ b/libsignal-protocol/src/macros.rs
@@ -51,14 +51,11 @@ macro_rules! signal_assert {
                 line!(),
                 stringify!($condition),
             );
-            ::log::error!("{}", ::failure::Backtrace::new());
+            let bt = ::failure::Backtrace::new().to_string();
+            if !bt.is_empty() {
+                ::log::error!("{}", bt);
+            }
 
-            eprintln!(
-                "Aborting because the application reached an unexpected state at {}#{}: {}",
-                file!(),
-                line!(),
-                stringify!($condition)
-            );
             return $ret.into();
         }
     };

--- a/libsignal-protocol/src/stores/identity_key_store.rs
+++ b/libsignal-protocol/src/stores/identity_key_store.rs
@@ -61,9 +61,9 @@ unsafe extern "C" fn get_identity_key_pair(
     private_data: *mut *mut sys::signal_buffer,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
-    assert!(!public_data.is_null());
-    assert!(!private_data.is_null());
+    signal_assert!(!user_data.is_null());
+    signal_assert!(!public_data.is_null());
+    signal_assert!(!private_data.is_null());
 
     let user_data = &*(user_data as *const State);
 
@@ -81,7 +81,7 @@ unsafe extern "C" fn get_local_registration_id(
     user_data: *mut c_void,
     registration_id: *mut u32,
 ) -> c_int {
-    assert!(!user_data.is_null());
+    signal_assert!(!user_data.is_null());
 
     let user_data = &*(user_data as *const State);
 
@@ -100,8 +100,8 @@ unsafe extern "C" fn save_identity(
     key_len: usize,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!address.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!address.is_null());
+    signal_assert!(!user_data.is_null());
 
     let user_data = &*(user_data as *const State);
     let address = Address::from_ptr(address);
@@ -123,9 +123,9 @@ unsafe extern "C" fn is_trusted_identity(
     key_len: usize,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!address.is_null());
-    assert!(!key_data.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!address.is_null());
+    signal_assert!(!key_data.is_null());
+    signal_assert!(!user_data.is_null());
 
     let user_data = &*(user_data as *const State);
     let address = Address::from_raw(sys::signal_protocol_address {

--- a/libsignal-protocol/src/stores/pre_key_store.rs
+++ b/libsignal-protocol/src/stores/pre_key_store.rs
@@ -39,8 +39,8 @@ unsafe extern "C" fn load_pre_key(
     pre_key_id: u32,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
-    assert!(!record.is_null());
+    signal_assert!(!user_data.is_null());
+    signal_assert!(!record.is_null());
     let user_data = &*(user_data as *const State);
     let mut buffer = Buffer::new();
 
@@ -59,8 +59,9 @@ unsafe extern "C" fn store_pre_key(
     record_len: usize,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
-    assert!(!record.is_null());
+    signal_assert!(!user_data.is_null());
+    signal_assert!(!record.is_null());
+
     let user_data = &*(user_data as *const State);
     let data = std::slice::from_raw_parts(record, record_len);
 
@@ -74,7 +75,8 @@ unsafe extern "C" fn contains_pre_key(
     pre_key_id: u32,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
+    signal_assert!(!user_data.is_null());
+
     let user_data = &*(user_data as *const State);
 
     user_data.0.contains(pre_key_id) as c_int
@@ -84,7 +86,8 @@ unsafe extern "C" fn remove_pre_key(
     pre_key_id: u32,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
+    signal_assert!(!user_data.is_null());
+
     let user_data = &*(user_data as *const State);
 
     match user_data.0.remove(pre_key_id) {

--- a/libsignal-protocol/src/stores/pre_key_store.rs
+++ b/libsignal-protocol/src/stores/pre_key_store.rs
@@ -2,11 +2,12 @@ use crate::{buffer::Buffer, errors::InternalError};
 use std::{
     io::{self, Write},
     os::raw::{c_int, c_void},
+    panic::RefUnwindSafe,
 };
 
 /// Something which can store [`crate::keys::PreKey`]s without inspecting their
 /// contents.
-pub trait PreKeyStore {
+pub trait PreKeyStore: RefUnwindSafe {
     /// Load a pre-key.
     fn load(&self, id: u32, writer: &mut dyn Write) -> io::Result<()>;
     /// Store a pre-key.
@@ -42,10 +43,24 @@ unsafe extern "C" fn load_pre_key(
     signal_assert!(!user_data.is_null());
     signal_assert!(!record.is_null());
     let user_data = &*(user_data as *const State);
-    let mut buffer = Buffer::new();
 
-    match user_data.0.load(pre_key_id, &mut buffer) {
-        Ok(_) => {
+    let got = signal_catch_unwind!({
+        let mut buffer = Buffer::new();
+        match user_data.0.load(pre_key_id, &mut buffer) {
+            Ok(_) => Ok(buffer),
+            Err(e) => {
+                log::error!(
+                    "An error occurred while trying to load pre-key {}: {}",
+                    pre_key_id,
+                    e
+                );
+                Err(InternalError::Unknown)
+            },
+        }
+    });
+
+    match got {
+        Ok(buffer) => {
             *record = buffer.into_raw();
             sys::SG_SUCCESS as c_int
         },
@@ -65,7 +80,7 @@ unsafe extern "C" fn store_pre_key(
     let user_data = &*(user_data as *const State);
     let data = std::slice::from_raw_parts(record, record_len);
 
-    match user_data.0.store(pre_key_id, data) {
+    match signal_catch_unwind!(user_data.0.store(pre_key_id, data)) {
         Ok(_) => sys::SG_SUCCESS as c_int,
         Err(e) => e.code(),
     }
@@ -79,7 +94,7 @@ unsafe extern "C" fn contains_pre_key(
 
     let user_data = &*(user_data as *const State);
 
-    user_data.0.contains(pre_key_id) as c_int
+    signal_catch_unwind!(user_data.0.contains(pre_key_id)) as c_int
 }
 
 unsafe extern "C" fn remove_pre_key(
@@ -90,7 +105,7 @@ unsafe extern "C" fn remove_pre_key(
 
     let user_data = &*(user_data as *const State);
 
-    match user_data.0.remove(pre_key_id) {
+    match signal_catch_unwind!(user_data.0.remove(pre_key_id)) {
         Ok(_) => sys::SG_SUCCESS as c_int,
         Err(e) => e.code(),
     }

--- a/libsignal-protocol/src/stores/session_store.rs
+++ b/libsignal-protocol/src/stores/session_store.rs
@@ -72,10 +72,10 @@ unsafe extern "C" fn load_session_func(
     address: *const sys::signal_protocol_address,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!record.is_null());
-    assert!(!user_record.is_null());
-    assert!(!address.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!record.is_null());
+    signal_assert!(!user_record.is_null());
+    signal_assert!(!address.is_null());
+    signal_assert!(!user_data.is_null());
 
     let state = &*(user_data as *const State);
     let address = Address::from_ptr(address);
@@ -103,9 +103,9 @@ unsafe extern "C" fn get_sub_device_sessions_func(
     name_len: usize,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!sessions.is_null());
-    assert!(!name.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!sessions.is_null());
+    signal_assert!(!name.is_null());
+    signal_assert!(!user_data.is_null());
 
     let state = &*(user_data as *const State);
     let name = std::slice::from_raw_parts(name as *const _, name_len);
@@ -136,9 +136,9 @@ unsafe extern "C" fn store_session_func(
     user_record_len: usize,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!address.is_null());
-    assert!(!record.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!address.is_null());
+    signal_assert!(!record.is_null());
+    signal_assert!(!user_data.is_null());
 
     let state = &*(user_data as *const State);
     let addr = Address::from_ptr(address);
@@ -164,8 +164,8 @@ unsafe extern "C" fn contains_session_func(
     address: *const sys::signal_protocol_address,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!address.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!address.is_null());
+    signal_assert!(!user_data.is_null());
 
     let state = &*(user_data as *const State);
     let addr = Address::from_ptr(address);
@@ -181,8 +181,8 @@ unsafe extern "C" fn delete_session_func(
     address: *const sys::signal_protocol_address,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!address.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!address.is_null());
+    signal_assert!(!user_data.is_null());
 
     let state = &*(user_data as *const State);
     let addr = Address::from_ptr(address);
@@ -198,8 +198,8 @@ unsafe extern "C" fn delete_all_sessions_func(
     name_len: usize,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!name.is_null());
-    assert!(!user_data.is_null());
+    signal_assert!(!name.is_null());
+    signal_assert!(!user_data.is_null());
 
     let state = &*(user_data as *const State);
     let name = std::slice::from_raw_parts(name as *const _, name_len);

--- a/libsignal-protocol/src/stores/signed_pre_key_store.rs
+++ b/libsignal-protocol/src/stores/signed_pre_key_store.rs
@@ -2,10 +2,11 @@ use crate::{buffer::Buffer, errors::InternalError};
 use std::{
     io::{self, Write},
     os::raw::{c_int, c_void},
+    panic::RefUnwindSafe,
 };
 
 /// Something which can store signed pre-keys without inspecting their contents.
-pub trait SignedPreKeyStore {
+pub trait SignedPreKeyStore: RefUnwindSafe {
     /// Load a signed pre-key.
     fn load(&self, id: u32, writer: &mut dyn Write) -> io::Result<()>;
     /// Store a signed pre-key.
@@ -45,10 +46,24 @@ unsafe extern "C" fn load_signed_pre_key(
     signal_assert!(!record.is_null());
 
     let user_data = &*(user_data as *const State);
-    let mut buffer = Buffer::new();
 
-    match user_data.0.load(pre_key_id, &mut buffer) {
-        Ok(_) => {
+    let got = signal_catch_unwind!({
+        let mut buffer = Buffer::new();
+        match user_data.0.load(pre_key_id, &mut buffer) {
+            Ok(_) => Ok(buffer),
+            Err(e) => {
+                log::error!(
+                    "An error occurred while trying to load the signed pre-key {}: {}",
+                    pre_key_id,
+                    e
+                );
+                Err(InternalError::Unknown)
+            },
+        }
+    });
+
+    match got {
+        Ok(buffer) => {
             *record = buffer.into_raw();
             sys::SG_SUCCESS as c_int
         },
@@ -68,7 +83,7 @@ unsafe extern "C" fn store_signed_pre_key(
     let user_data = &*(user_data as *const State);
     let data = std::slice::from_raw_parts(record, record_len);
 
-    match user_data.0.store(pre_key_id, data) {
+    match signal_catch_unwind!(user_data.0.store(pre_key_id, data)) {
         Ok(_) => sys::SG_SUCCESS as c_int,
         Err(e) => e.code(),
     }
@@ -82,7 +97,7 @@ unsafe extern "C" fn contains_signed_pre_key(
 
     let user_data = &*(user_data as *const State);
 
-    user_data.0.contains(pre_key_id) as c_int
+    signal_catch_unwind!(user_data.0.contains(pre_key_id) as c_int)
 }
 
 unsafe extern "C" fn remove_signed_pre_key(
@@ -93,7 +108,7 @@ unsafe extern "C" fn remove_signed_pre_key(
 
     let user_data = &*(user_data as *const State);
 
-    match user_data.0.remove(pre_key_id) {
+    match signal_catch_unwind!(user_data.0.remove(pre_key_id)) {
         Ok(_) => sys::SG_SUCCESS as c_int,
         Err(e) => e.code(),
     }

--- a/libsignal-protocol/src/stores/signed_pre_key_store.rs
+++ b/libsignal-protocol/src/stores/signed_pre_key_store.rs
@@ -41,8 +41,9 @@ unsafe extern "C" fn load_signed_pre_key(
     pre_key_id: u32,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
-    assert!(!record.is_null());
+    signal_assert!(!user_data.is_null());
+    signal_assert!(!record.is_null());
+
     let user_data = &*(user_data as *const State);
     let mut buffer = Buffer::new();
 
@@ -61,8 +62,9 @@ unsafe extern "C" fn store_signed_pre_key(
     record_len: usize,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
-    assert!(!record.is_null());
+    signal_assert!(!user_data.is_null());
+    signal_assert!(!record.is_null());
+
     let user_data = &*(user_data as *const State);
     let data = std::slice::from_raw_parts(record, record_len);
 
@@ -76,7 +78,8 @@ unsafe extern "C" fn contains_signed_pre_key(
     pre_key_id: u32,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
+    signal_assert!(!user_data.is_null());
+
     let user_data = &*(user_data as *const State);
 
     user_data.0.contains(pre_key_id) as c_int
@@ -86,7 +89,8 @@ unsafe extern "C" fn remove_signed_pre_key(
     pre_key_id: u32,
     user_data: *mut c_void,
 ) -> c_int {
-    assert!(!user_data.is_null());
+    signal_assert!(!user_data.is_null());
+
     let user_data = &*(user_data as *const State);
 
     match user_data.0.remove(pre_key_id) {


### PR DESCRIPTION
This PR tries to make sure a panic emitted from our `extern "C"` trampolines don't accidentally cross the FFI barrier into C.

In particular, this:

- Replaces all `assert!()` calls with a `signal_assert!()` macro that logs the assertions, logs a backtrace, and then return an `InternalError`, in most cases it would be `InternalError::InvalidArgument`.
- Wrap all calls into a user-defined trait object (e.g. `Crypto` or `SessionStore`) with `std::panic::catch_unwind()` so we can log panics and return with an `InternalError::Unknown`
- Adds the `std::panic::RefUnwindSafe` constraint to most user-defined trait objects because they need to be able to handle panics that may happen while operating on the object's internals (e.g. by implementing poisoning like `Mutex` does)

Closes #33.