### PR TITLE
Types that should return InternalError in favour of `failure::Error`.

### DIFF
--- a/libsignal-protocol/Cargo.toml
+++ b/libsignal-protocol/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings", "cryptography"]
 libsignal-protocol-sys = { path = "../libsignal-protocol-sys/" }
 #libsignal-protocol-sys = "0.1.0"
 failure = "0.1.5"
-failure_derive = "0.1.5"
+thiserror = "1.0.0"
 rand = "0.7.3"
 log = "0.4.6"
 static_assertions = "1.1.0"

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -1,30 +1,47 @@
-use std::{
-    convert::TryFrom,
-    fmt::{self, Display, Formatter},
-};
+use std::convert::TryFrom;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, failure_derive::Fail)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum InternalError {
+    #[error("No Memory")]
     NoMemory,
+    #[error("Invalid argument")]
     InvalidArgument,
+    #[error("Unknown error")]
     Unknown,
+    #[error("Duplicate message")]
     DuplicateMessage,
+    #[error("Invalid key")]
     InvalidKey,
+    #[error("Invalid key ID")]
     InvalidKeyId,
+    #[error("Invalid MAC")]
     InvalidMAC,
+    #[error("Invalid message")]
     InvalidMessage,
+    #[error("Invalid version")]
     InvalidVersion,
+    #[error("Legacy message")]
     LegacyMessage,
+    #[error("No session")]
     NoSession,
+    #[error("Stale key exchange")]
     StaleKeyExchange,
+    #[error("Untrusted identity")]
     UntrustedIdentity,
+    #[error("Varifying signature failed")]
     VerifySignatureVerificationFailed,
+    #[error("Invalid protobuf")]
     InvalidProtoBuf,
+    #[error("FP version mismatched")]
     FPVersionMismatch,
+    #[error("FP ident mismatched")]
     FPIdentMismatch,
+    #[error("Unknown error {0}")]
     Other(i32),
+    #[error("Unknown ciphertext type {0}")]
     UnknownCiphertextType(u32),
+    #[error("Cannot serialize")]
     SerializationError,
 }
 
@@ -140,37 +157,4 @@ impl<T> IntoInternalErrorCode for Result<T, InternalError> {
 
 impl From<InternalError> for i32 {
     fn from(other: InternalError) -> i32 { other.code() }
-}
-
-impl Display for InternalError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            InternalError::NoMemory => write!(f, "No Memory"),
-            InternalError::InvalidArgument => write!(f, "Invalid argument"),
-            InternalError::Unknown => write!(f, "Unknown error"),
-            InternalError::DuplicateMessage => write!(f, "Duplicate message"),
-            InternalError::InvalidKey => write!(f, "Invalid key"),
-            InternalError::InvalidKeyId => write!(f, "Invalid key ID"),
-            InternalError::InvalidMAC => write!(f, "Invalid MAC"),
-            InternalError::InvalidMessage => write!(f, "Invalid message"),
-            InternalError::InvalidVersion => write!(f, "Invalid version"),
-            InternalError::LegacyMessage => write!(f, "Legacy message"),
-            InternalError::NoSession => write!(f, "No session"),
-            InternalError::StaleKeyExchange => write!(f, "Stale key exchange"),
-            InternalError::UntrustedIdentity => write!(f, "Untrusted identity"),
-            InternalError::VerifySignatureVerificationFailed => {
-                write!(f, "Verifying signature failed")
-            },
-            InternalError::InvalidProtoBuf => write!(f, "Invalid protobuf"),
-            InternalError::FPVersionMismatch => {
-                write!(f, "FP version mismatched")
-            },
-            InternalError::FPIdentMismatch => write!(f, "FP ident mismatched"),
-            InternalError::Other(code) => write!(f, "Unknown error {}", code),
-            InternalError::UnknownCiphertextType(t) => {
-                write!(f, "Unknown ciphertext type {}", t)
-            },
-            InternalError::SerializationError => write!(f, "Cannot serialize"),
-        }
-    }
 }

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -24,6 +24,8 @@ pub enum InternalError {
     FPVersionMismatch,
     FPIdentMismatch,
     Other(i32),
+    UnknownCiphertextType(u32),
+    SerializationError,
 }
 
 impl InternalError {
@@ -88,6 +90,10 @@ impl InternalError {
             InternalError::FPVersionMismatch => sys::SG_ERR_FP_VERSION_MISMATCH,
             InternalError::FPIdentMismatch => sys::SG_ERR_FP_IDENT_MISMATCH,
             InternalError::Other(c) => c,
+            InternalError::UnknownCiphertextType(_) => {
+                sys::SG_ERR_INVALID_PROTO_BUF
+            },
+            InternalError::SerializationError => sys::SG_ERR_INVALID_PROTO_BUF,
         }
     }
 }
@@ -161,6 +167,10 @@ impl Display for InternalError {
             },
             InternalError::FPIdentMismatch => write!(f, "FP ident mismatched"),
             InternalError::Other(code) => write!(f, "Unknown error {}", code),
+            InternalError::UnknownCiphertextType(t) => {
+                write!(f, "Unknown ciphertext type {}", t)
+            },
+            InternalError::SerializationError => write!(f, "Cannot serialize"),
         }
     }
 }

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -71,8 +71,6 @@ extern crate rental;
 
 use std::io::Write;
 
-use failure::Error;
-
 pub use crate::{
     address::Address,
     buffer::Buffer,
@@ -118,10 +116,13 @@ pub mod stores;
 /// A helper trait for something which can be serialized to protobufs.
 pub trait Serializable {
     /// Serialize the object to a buffer.
-    fn serialize(&self) -> Result<Buffer, Error>;
+    fn serialize(&self) -> Result<Buffer, InternalError>;
 
     /// Helper for serializing to anything which implements [`Write`].
-    fn serialize_to<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+    fn serialize_to<W: Write>(
+        &self,
+        mut writer: W,
+    ) -> Result<(), failure::Error> {
         let buffer = self.serialize()?;
         writer.write_all(buffer.as_slice())?;
 
@@ -132,5 +133,5 @@ pub trait Serializable {
 /// A helper trait for something which can be deserialized from protobufs.
 pub trait Deserializable: Sized {
     /// Parse the provided data in the protobuf format.
-    fn deserialize(ctx: &Context, data: &[u8]) -> Result<Self, Error>;
+    fn deserialize(ctx: &Context, data: &[u8]) -> Result<Self, InternalError>;
 }

--- a/libsignal-protocol/src/macros.rs
+++ b/libsignal-protocol/src/macros.rs
@@ -1,7 +1,9 @@
 macro_rules! impl_serializable {
     ($name:ty, $serialize:ident) => {
         impl $crate::Serializable for $name {
-            fn serialize(&self) -> Result<$crate::Buffer, failure::Error> {
+            fn serialize(
+                &self,
+            ) -> Result<$crate::Buffer, $crate::errors::InternalError> {
                 #[allow(unused_imports)]
                 use $crate::errors::FromInternalErrorCode;
 
@@ -29,7 +31,7 @@ macro_rules! impl_deserializable {
             fn deserialize(
                 ctx: &$crate::Context,
                 data: &[u8],
-            ) -> Result<Self, failure::Error> {
+            ) -> Result<Self, $crate::errors::InternalError> {
                 use failure::ResultExt;
                 use $crate::errors::FromInternalErrorCode;
 
@@ -42,8 +44,7 @@ macro_rules! impl_deserializable {
                         data.len() as _,
                         ctx.raw(),
                     )
-                    .into_result()
-                    .context("Unable to deserialize buffer")?;
+                    .into_result()?;
 
                     let $raw =
                         $crate::raw_ptr::Raw::from_ptr(raw.assume_init());

--- a/libsignal-protocol/src/session_cipher.rs
+++ b/libsignal-protocol/src/session_cipher.rs
@@ -1,13 +1,12 @@
 use crate::{
     context::{Context, ContextInner},
-    errors::FromInternalErrorCode,
+    errors::{FromInternalErrorCode, InternalError},
     messages::{CiphertextMessage, PreKeySignalMessage, SignalMessage},
     raw_ptr::Raw,
     store_context::{StoreContext, StoreContextInner},
     Address, Buffer,
 };
 
-use failure::Error;
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,
@@ -28,7 +27,7 @@ impl SessionCipher {
         ctx: &Context,
         store_ctx: &StoreContext,
         address: &Address,
-    ) -> Result<SessionCipher, Error> {
+    ) -> Result<SessionCipher, InternalError> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::session_cipher_create(
@@ -49,7 +48,10 @@ impl SessionCipher {
     }
 
     /// Encrypt a message.
-    pub fn encrypt(&self, message: &[u8]) -> Result<CiphertextMessage, Error> {
+    pub fn encrypt(
+        &self,
+        message: &[u8],
+    ) -> Result<CiphertextMessage, InternalError> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::session_cipher_encrypt(
@@ -71,7 +73,7 @@ impl SessionCipher {
     pub fn decrypt_pre_key_message(
         &self,
         message: &PreKeySignalMessage,
-    ) -> Result<Buffer, Error> {
+    ) -> Result<Buffer, InternalError> {
         unsafe {
             let mut buffer = ptr::null_mut();
             sys::session_cipher_decrypt_pre_key_signal_message(
@@ -81,7 +83,7 @@ impl SessionCipher {
                 &mut buffer,
             )
             .into_result()?;
-            
+
             Ok(Buffer::from_raw(buffer))
         }
     }
@@ -90,7 +92,7 @@ impl SessionCipher {
     pub fn decrypt_message(
         &self,
         message: &SignalMessage,
-    ) -> Result<Buffer, Error> {
+    ) -> Result<Buffer, InternalError> {
         unsafe {
             let mut buffer = ptr::null_mut();
             sys::session_cipher_decrypt_signal_message(
@@ -100,7 +102,7 @@ impl SessionCipher {
                 &mut buffer,
             )
             .into_result()?;
-            
+
             Ok(Buffer::from_raw(buffer))
         }
     }

--- a/libsignal-protocol/src/store_context.rs
+++ b/libsignal-protocol/src/store_context.rs
@@ -1,11 +1,10 @@
 use crate::{
     context::ContextInner,
     errors::{FromInternalErrorCode, InternalError},
-    keys::{SessionSignedPreKey, PreKey},
+    keys::{PreKey, SessionSignedPreKey},
     raw_ptr::Raw,
     Address, SessionRecord,
 };
-use failure::Error;
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,
@@ -31,10 +30,7 @@ impl StoreContext {
     }
 
     /// Store pre key
-    pub fn store_pre_key(
-        &self,
-        pre_key: &PreKey,
-    ) -> Result<(), Error> {
+    pub fn store_pre_key(&self, pre_key: &PreKey) -> Result<(), InternalError> {
         unsafe {
             sys::signal_protocol_pre_key_store_key(
                 self.raw(),
@@ -50,7 +46,7 @@ impl StoreContext {
     pub fn store_signed_pre_key(
         &self,
         signed_pre_key: &SessionSignedPreKey,
-    ) -> Result<(), Error> {
+    ) -> Result<(), InternalError> {
         unsafe {
             sys::signal_protocol_signed_pre_key_store_key(
                 self.raw(),
@@ -63,7 +59,7 @@ impl StoreContext {
     }
 
     /// Get the registration ID.
-    pub fn registration_id(&self) -> Result<u32, Error> {
+    pub fn registration_id(&self) -> Result<u32, InternalError> {
         unsafe {
             let mut id = 0;
             sys::signal_protocol_identity_get_local_registration_id(
@@ -77,7 +73,10 @@ impl StoreContext {
     }
 
     /// Does this store already contain a session with the provided recipient?
-    pub fn contains_session(&self, addr: &Address) -> Result<bool, Error> {
+    pub fn contains_session(
+        &self,
+        addr: &Address,
+    ) -> Result<bool, InternalError> {
         unsafe {
             match sys::signal_protocol_session_contains_session(
                 self.raw(),
@@ -85,16 +84,17 @@ impl StoreContext {
             ) {
                 0 => Ok(false),
                 1 => Ok(true),
-                code => Err(Error::from(
-                    InternalError::from_error_code(code)
-                        .unwrap_or(InternalError::Unknown),
-                )),
+                code => Err(InternalError::from_error_code(code)
+                    .unwrap_or(InternalError::Unknown)),
             }
         }
     }
 
     /// Load the session corresponding to the provided recipient.
-    pub fn load_session(&self, addr: &Address) -> Result<SessionRecord, Error> {
+    pub fn load_session(
+        &self,
+        addr: &Address,
+    ) -> Result<SessionRecord, InternalError> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::signal_protocol_session_load_session(


### PR DESCRIPTION
Partially resolves #59. Still many places that return `failure::Error`, but those are more difficult to refactor quickly.