### PR TITLE
Implement Display for PublicKey using base64 encoding

### DIFF
--- a/libsignal-protocol/Cargo.toml
+++ b/libsignal-protocol/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1.0.0"
 rand = "0.7.3"
 log = "0.4.6"
 static_assertions = "1.1.0"
+base64 = "0.12"
 
 # -- Optional Crates -- #
 openssl = { version = "0.10", optional = true }

--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::{Ord, Ordering},
+    fmt::{self, Display},
     ptr,
 };
 
@@ -8,7 +9,7 @@ use failure::Error;
 use crate::{
     errors::{FromInternalErrorCode, InternalError},
     raw_ptr::Raw,
-    Context,
+    Buffer, Context,
 };
 
 /// The public part of an elliptic curve key pair.
@@ -94,6 +95,18 @@ impl Eq for PublicKey {}
 impl PartialOrd for PublicKey {
     fn partial_cmp(&self, other: &PublicKey) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unsafe {
+            let mut raw = ptr::null_mut();
+            sys::ec_public_key_serialize(&mut raw, self.raw.as_const_ptr())
+                .into_result()
+                .map_err(|_| fmt::Error)?;
+            f.write_str(&base64::encode(Buffer::from_raw(raw).as_slice()))
+        }
     }
 }
 

--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -63,6 +63,16 @@ impl PublicKey {
             }
         }
     }
+
+    /// returns this public key as a base64 encoded string
+    pub fn as_base64(&self) -> Result<String, InternalError> {
+        unsafe {
+            let mut raw = ptr::null_mut();
+            sys::ec_public_key_serialize(&mut raw, self.raw.as_const_ptr())
+                .into_result()?;
+            Ok(base64::encode(Buffer::from_raw(raw).as_slice()))
+        }
+    }
 }
 
 impl Ord for PublicKey {
@@ -100,13 +110,7 @@ impl PartialOrd for PublicKey {
 
 impl Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unsafe {
-            let mut raw = ptr::null_mut();
-            sys::ec_public_key_serialize(&mut raw, self.raw.as_const_ptr())
-                .into_result()
-                .map_err(|_| fmt::Error)?;
-            f.write_str(&base64::encode(Buffer::from_raw(raw).as_slice()))
-        }
+        f.write_str(&self.as_base64().map_err(|_| fmt::Error)?)
     }
 }
 


### PR DESCRIPTION
This is one piece missing to be able to generate a `tsdevice://` link for secondary device provisioning in [libsignal-service-rs](https://github.com/Michael-F-Bryan/libsignal-service-rs).