### PR TITLE
Replace failure by thiserror/anyhow

### DIFF
--- a/libsignal-protocol-sys/build.rs
+++ b/libsignal-protocol-sys/build.rs
@@ -116,7 +116,7 @@ fn get_cmake_config() -> cmake::Config {
             }
 
             libsignal_cmake
-        }
+        },
 
         "ios" => {
             for (ios_arch, params) in CMAKE_PARAMS_IOS {
@@ -133,7 +133,7 @@ fn get_cmake_config() -> cmake::Config {
             libsignal_cmake.cflag("-fembed-bitcode");
 
             libsignal_cmake
-        }
+        },
 
         _ => libsignal_cmake,
     };

--- a/libsignal-protocol/Cargo.toml
+++ b/libsignal-protocol/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "cryptography"]
 [dependencies]
 libsignal-protocol-sys = { path = "../libsignal-protocol-sys/" }
 #libsignal-protocol-sys = "0.1.0"
-failure = "0.1.5"
+backtrace = "0.3"
 thiserror = "1.0.0"
 rand = "0.7.3"
 log = "0.4.6"
@@ -38,5 +38,6 @@ crypto-native = ["sha2", "hmac", "aes", "block-modes", "aes-ctr"]
 crypto-openssl = ["openssl", "rental"]
 
 [dev-dependencies]
+anyhow = "1.0"
 cfg-if = "0.1.9"
 env_logger = "0.7.1"

--- a/libsignal-protocol/examples/generate_keys.rs
+++ b/libsignal-protocol/examples/generate_keys.rs
@@ -27,7 +27,7 @@ extern crate libsignal_protocol as sig;
 
 use std::time::SystemTime;
 
-use failure::Error;
+use anyhow::Error;
 
 use sig::Context;
 

--- a/libsignal-protocol/examples/sessions.rs
+++ b/libsignal-protocol/examples/sessions.rs
@@ -47,15 +47,15 @@ extern crate libsignal_protocol as sig;
 
 use std::time::SystemTime;
 
-use failure::{Error, ResultExt};
+use anyhow::{Context, Error};
 
 use sig::{
     stores::{
         InMemoryIdentityKeyStore, InMemoryPreKeyStore, InMemorySessionStore,
         InMemorySignedPreKeyStore,
     },
-    Address, Context, PreKeyBundle, Serializable, SessionBuilder,
-    SessionCipher,
+    Address, Context as SignalContext, PreKeyBundle, Serializable,
+    SessionBuilder, SessionCipher,
 };
 
 #[path = "../tests/helpers/mod.rs"]
@@ -72,7 +72,7 @@ cfg_if::cfg_if! {
 }
 fn main() -> Result<(), Error> {
     env_logger::init();
-    let ctx = Context::new(Crypto::default()).unwrap();
+    let ctx = SignalContext::new(Crypto::default()).unwrap();
 
     // first we'll need a copy of bob's public key and some of his pre-keys
     let bob_address = Address::new("+14159998888", 1);

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -73,7 +73,7 @@ pub fn generate_key_pair(ctx: &Context) -> Result<KeyPair, Error> {
 ///
 /// ```rust
 /// # use libsignal_protocol::{keys::PublicKey, Context};
-/// # use failure::Error;
+/// # use anyhow::Error;
 /// # use cfg_if::cfg_if;
 /// # fn main() -> Result<(), Error> {
 /// # cfg_if::cfg_if! {

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -14,10 +14,10 @@ use std::{
 use log::Level;
 
 #[cfg(feature = "crypto-native")]
-use crate::{crypto::DefaultCrypto, errors::Error};
+use crate::crypto::DefaultCrypto;
 use crate::{
     crypto::{Crypto, CryptoProvider},
-    errors::FromInternalErrorCode,
+    errors::{Error, FromInternalErrorCode},
     hkdf::HMACBasedKeyDerivationFunction,
     keys::{
         IdentityKeyPair, KeyPair, PreKeyList, PrivateKey, SessionSignedPreKey,

--- a/libsignal-protocol/src/context.rs
+++ b/libsignal-protocol/src/context.rs
@@ -17,7 +17,7 @@ use log::Level;
 use crate::{crypto::DefaultCrypto, errors::Error};
 use crate::{
     crypto::{Crypto, CryptoProvider},
-    errors::{FromInternalErrorCode},
+    errors::FromInternalErrorCode,
     hkdf::HMACBasedKeyDerivationFunction,
     keys::{
         IdentityKeyPair, KeyPair, PreKeyList, PrivateKey, SessionSignedPreKey,

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -1,5 +1,45 @@
 use std::convert::TryFrom;
 
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error("internal error: {0}")]
+    InternalError(#[from] InternalError),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("invalid signature")]
+    InvalidSignature,
+    #[error("failed to calculate secrets")]
+    SecretsCalculationError,
+    #[error("system time error: {0}")]
+    SystemTimeError(#[from] std::time::SystemTimeError),
+    #[error("expected a pre-key ciphertext message")]
+    NoPreKeyCipherTextMessage,
+    #[error("expected a signal message")]
+    NoSignalMessage,
+    #[error("unable to generate a signed pre key")]
+    SignedPreKeyGenerationError,
+    #[error("unable to get the pre-key")]
+    PreKeyGetError,
+    #[error("unable to get the signed pre-key")]
+    SignedPreKeyGetError,
+    #[error("unable to get the identity key")]
+    IdentityKeyGetError,
+    #[error("a missing field is required: {0}")]
+    MissingRequiredField(RequiredField),
+}
+
+#[derive(Debug, Copy, Clone, thiserror::Error)]
+pub enum RequiredField {
+    #[error("registration ID")]
+    RegistrationId,
+    #[error("device ID")]
+    DeviceId,
+    #[error("identity key is missing")]
+    IdentityKey,
+}
+
+/// Mapping of internal errors that can happen inside of libsignal-protocol-c
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum InternalError {
@@ -29,7 +69,7 @@ pub enum InternalError {
     StaleKeyExchange,
     #[error("Untrusted identity")]
     UntrustedIdentity,
-    #[error("Varifying signature failed")]
+    #[error("Verifying signature failed")]
     VerifySignatureVerificationFailed,
     #[error("Invalid protobuf")]
     InvalidProtoBuf,

--- a/libsignal-protocol/src/errors.rs
+++ b/libsignal-protocol/src/errors.rs
@@ -27,6 +27,10 @@ pub enum Error {
     IdentityKeyGetError,
     #[error("a missing field is required: {0}")]
     MissingRequiredField(RequiredField),
+    #[error("unknown error: {reason}")]
+    Unknown {
+        reason: String
+    }
 }
 
 #[derive(Debug, Copy, Clone, thiserror::Error)]
@@ -37,6 +41,17 @@ pub enum RequiredField {
     DeviceId,
     #[error("identity key is missing")]
     IdentityKey,
+}
+
+impl Error {
+    /// Get the error code for libsignal-protocol-c.
+    /// For anything else than InternalError, returns SG_ERR_UNKNOWN.
+    pub(crate) fn code(self) -> i32 {
+        match self {
+            Error::InternalError(e) => e.code(),
+            _ => sys::SG_ERR_UNKNOWN,
+        }
+    }
 }
 
 /// Mapping of internal errors that can happen inside of libsignal-protocol-c

--- a/libsignal-protocol/src/hkdf.rs
+++ b/libsignal-protocol/src/hkdf.rs
@@ -1,10 +1,9 @@
 use crate::{
     context::ContextInner,
-    errors::{FromInternalErrorCode, InternalError},
+    errors::{Error, FromInternalErrorCode, InternalError},
     raw_ptr::Raw,
     Context,
 };
-use failure::Error;
 use std::{ptr, rc::Rc};
 
 /// Context for a HMAC-based Key Derivation Function.

--- a/libsignal-protocol/src/keys/identity_key_pair.rs
+++ b/libsignal-protocol/src/keys/identity_key_pair.rs
@@ -1,9 +1,8 @@
 use crate::{
-    errors::FromInternalErrorCode,
+    errors::{Error, FromInternalErrorCode},
     keys::{PrivateKey, PublicKey},
     raw_ptr::Raw,
 };
-use failure::Error;
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,

--- a/libsignal-protocol/src/keys/key_pair.rs
+++ b/libsignal-protocol/src/keys/key_pair.rs
@@ -1,9 +1,8 @@
 use crate::{
-    errors::FromInternalErrorCode,
+    errors::{Error, FromInternalErrorCode},
     keys::{PrivateKey, PublicKey},
     raw_ptr::Raw,
 };
-use failure::Error;
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,

--- a/libsignal-protocol/src/keys/pre_key.rs
+++ b/libsignal-protocol/src/keys/pre_key.rs
@@ -1,5 +1,8 @@
-use crate::{errors::FromInternalErrorCode, keys::KeyPair, raw_ptr::Raw};
-use failure::Error;
+use crate::{
+    errors::{Error, FromInternalErrorCode},
+    keys::KeyPair,
+    raw_ptr::Raw,
+};
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,

--- a/libsignal-protocol/src/keys/private.rs
+++ b/libsignal-protocol/src/keys/private.rs
@@ -1,8 +1,9 @@
 use crate::{
-    errors::FromInternalErrorCode, keys::PublicKey, raw_ptr::Raw, Buffer,
-    Context,
+    errors::{Error, FromInternalErrorCode},
+    keys::PublicKey,
+    raw_ptr::Raw,
+    Buffer, Context,
 };
-use failure::Error;
 use std::{
     cmp::{Ord, Ordering},
     ptr,

--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -4,10 +4,8 @@ use std::{
     ptr,
 };
 
-use failure::Error;
-
 use crate::{
-    errors::{FromInternalErrorCode, InternalError},
+    errors::{Error, FromInternalErrorCode, InternalError},
     keys::PrivateKey,
     raw_ptr::Raw,
     Buffer, Context,
@@ -56,11 +54,11 @@ impl PublicKey {
             if result == 1 {
                 Ok(())
             } else if result == 0 {
-                Err(failure::err_msg("Invalid signature"))
+                Err(Error::InvalidSignature)
             } else if let Some(err) = InternalError::from_error_code(result) {
                 Err(err.into())
             } else {
-                Err(failure::format_err!("Unknown error code: {}", result))
+                Err(Error::InternalError(InternalError::Other(result)))
             }
         }
     }
@@ -88,11 +86,10 @@ impl PublicKey {
                 libc::free(shared_data as *mut libc::c_void);
                 Ok(secret)
             } else {
-                Err(failure::err_msg("Error while calculating shared secret"))
+                Err(Error::SecretsCalculationError)
             }
         }
     }
-
 
     /// returns this public key as a base64 encoded string
     pub fn as_base64(&self) -> Result<String, InternalError> {

--- a/libsignal-protocol/src/keys/signed_pre_key.rs
+++ b/libsignal-protocol/src/keys/signed_pre_key.rs
@@ -1,5 +1,8 @@
-use crate::{errors::FromInternalErrorCode, keys::KeyPair, raw_ptr::Raw};
-use failure::Error;
+use crate::{
+    errors::{Error, FromInternalErrorCode},
+    keys::KeyPair,
+    raw_ptr::Raw,
+};
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -59,7 +59,7 @@
     clippy::cargo_common_metadata,
     clippy::fallible_impl_from,
     clippy::missing_const_for_fn,
-    intra_doc_link_resolution_failure
+    broken_intra_doc_links
 )]
 
 // we use the *-sys crate everywhere so give it a shorter name

--- a/libsignal-protocol/src/lib.rs
+++ b/libsignal-protocol/src/lib.rs
@@ -75,7 +75,9 @@ pub use crate::{
     address::Address,
     buffer::Buffer,
     context::*,
-    errors::{FromInternalErrorCode, InternalError, IntoInternalErrorCode},
+    errors::{
+        Error, FromInternalErrorCode, InternalError, IntoInternalErrorCode,
+    },
     hkdf::HMACBasedKeyDerivationFunction,
     pre_key_bundle::{PreKeyBundle, PreKeyBundleBuilder},
     session_builder::SessionBuilder,
@@ -116,13 +118,13 @@ pub mod stores;
 /// A helper trait for something which can be serialized to protobufs.
 pub trait Serializable {
     /// Serialize the object to a buffer.
-    fn serialize(&self) -> Result<Buffer, InternalError>;
+    fn serialize(&self) -> Result<Buffer, Error>;
 
     /// Helper for serializing to anything which implements [`Write`].
     fn serialize_to<W: Write>(
         &self,
         mut writer: W,
-    ) -> Result<(), failure::Error> {
+    ) -> Result<(), errors::Error> {
         let buffer = self.serialize()?;
         writer.write_all(buffer.as_slice())?;
 
@@ -133,5 +135,5 @@ pub trait Serializable {
 /// A helper trait for something which can be deserialized from protobufs.
 pub trait Deserializable: Sized {
     /// Parse the provided data in the protobuf format.
-    fn deserialize(ctx: &Context, data: &[u8]) -> Result<Self, InternalError>;
+    fn deserialize(ctx: &Context, data: &[u8]) -> Result<Self, Error>;
 }

--- a/libsignal-protocol/src/macros.rs
+++ b/libsignal-protocol/src/macros.rs
@@ -3,7 +3,7 @@ macro_rules! impl_serializable {
         impl $crate::Serializable for $name {
             fn serialize(
                 &self,
-            ) -> Result<$crate::Buffer, $crate::errors::InternalError> {
+            ) -> Result<$crate::Buffer, $crate::errors::Error> {
                 #[allow(unused_imports)]
                 use $crate::errors::FromInternalErrorCode;
 
@@ -31,8 +31,7 @@ macro_rules! impl_deserializable {
             fn deserialize(
                 ctx: &$crate::Context,
                 data: &[u8],
-            ) -> Result<Self, $crate::errors::InternalError> {
-                use failure::ResultExt;
+            ) -> Result<Self, $crate::errors::Error> {
                 use $crate::errors::FromInternalErrorCode;
 
                 let mut raw = std::mem::MaybeUninit::uninit();
@@ -85,10 +84,8 @@ macro_rules! signal_assert {
                 line!(),
                 stringify!($condition),
             );
-            let bt = ::failure::Backtrace::new().to_string();
-            if !bt.is_empty() {
-                ::log::error!("{}", bt);
-            }
+            let bt = backtrace::Backtrace::new();
+            ::log::error!("{:?}", bt);
 
             return $ret.into();
         }

--- a/libsignal-protocol/src/messages/ciphertext_message.rs
+++ b/libsignal-protocol/src/messages/ciphertext_message.rs
@@ -1,4 +1,7 @@
-use crate::{Buffer, ContextInner, Error, Serializable, errors::InternalError, raw_ptr::Raw};
+use crate::{
+    errors::InternalError, raw_ptr::Raw, Buffer, ContextInner, Error,
+    Serializable,
+};
 use std::{convert::TryFrom, rc::Rc};
 
 // For rustdoc link resolution
@@ -57,7 +60,9 @@ impl Serializable for CiphertextMessage {
                 sys::ciphertext_message_get_serialized(self.raw.as_const_ptr());
 
             if buffer.is_null() {
-                return Err(Error::InternalError(InternalError::SerializationError));
+                return Err(Error::InternalError(
+                    InternalError::SerializationError,
+                ));
             }
 
             let temporary_not_owned_buffer = Buffer::from_raw(buffer);

--- a/libsignal-protocol/src/messages/ciphertext_message.rs
+++ b/libsignal-protocol/src/messages/ciphertext_message.rs
@@ -1,6 +1,4 @@
-use crate::{
-    errors::InternalError, raw_ptr::Raw, Buffer, ContextInner, Serializable,
-};
+use crate::{Buffer, ContextInner, Error, Serializable, errors::InternalError, raw_ptr::Raw};
 use std::{convert::TryFrom, rc::Rc};
 
 // For rustdoc link resolution
@@ -52,14 +50,14 @@ impl CiphertextMessage {
 }
 
 impl Serializable for CiphertextMessage {
-    fn serialize(&self) -> Result<Buffer, InternalError> {
+    fn serialize(&self) -> Result<Buffer, Error> {
         unsafe {
             // get a reference to the *cached* serialized message
             let buffer =
                 sys::ciphertext_message_get_serialized(self.raw.as_const_ptr());
 
             if buffer.is_null() {
-                return Err(InternalError::SerializationError);
+                return Err(Error::InternalError(InternalError::SerializationError));
             }
 
             let temporary_not_owned_buffer = Buffer::from_raw(buffer);

--- a/libsignal-protocol/src/messages/pre_key_signal_message.rs
+++ b/libsignal-protocol/src/messages/pre_key_signal_message.rs
@@ -1,10 +1,10 @@
 use crate::{
+    errors::Error,
     keys::PublicKey,
     messages::{CiphertextMessage, CiphertextType, SignalMessage},
     raw_ptr::Raw,
     ContextInner,
 };
-use failure::Error;
 use std::{convert::TryFrom, rc::Rc};
 
 /// A message containing everything necessary to establish a session.
@@ -109,7 +109,7 @@ impl TryFrom<CiphertextMessage> for PreKeySignalMessage {
 
     fn try_from(other: CiphertextMessage) -> Result<Self, Self::Error> {
         if other.get_type()? != CiphertextType::PreKey {
-            Err(failure::err_msg("Expected a pre-key ciphertext message"))
+            Err(Error::NoPreKeyCipherTextMessage)
         } else {
             // safety: the `CiphertextType` check tells us this is actually a
             // pointer to a `pre_key_signal_message`

--- a/libsignal-protocol/src/messages/signal_message.rs
+++ b/libsignal-protocol/src/messages/signal_message.rs
@@ -1,11 +1,10 @@
 use crate::{
-    errors::InternalError,
+    errors::{Error, InternalError},
     keys::PublicKey,
     messages::{CiphertextMessage, CiphertextType},
     raw_ptr::Raw,
     Context, ContextInner,
 };
-use failure::Error;
 use std::{convert::TryFrom, rc::Rc};
 
 // For rustdoc link resolution
@@ -95,7 +94,7 @@ impl TryFrom<CiphertextMessage> for SignalMessage {
 
     fn try_from(other: CiphertextMessage) -> Result<Self, Self::Error> {
         if other.get_type()? != CiphertextType::Signal {
-            Err(failure::err_msg("Expected a signal message"))
+            Err(Error::NoSignalMessage)
         } else {
             // safety: the `CiphertextType` check tells us this is actually a
             // pointer to a `signal_message`

--- a/libsignal-protocol/src/session_builder.rs
+++ b/libsignal-protocol/src/session_builder.rs
@@ -1,4 +1,11 @@
-use crate::{address::Address, Error, context::{Context, ContextInner}, errors::{FromInternalErrorCode}, pre_key_bundle::PreKeyBundle, store_context::{StoreContext, StoreContextInner}};
+use crate::{
+    address::Address,
+    context::{Context, ContextInner},
+    errors::FromInternalErrorCode,
+    pre_key_bundle::PreKeyBundle,
+    store_context::{StoreContext, StoreContextInner},
+    Error,
+};
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,

--- a/libsignal-protocol/src/session_builder.rs
+++ b/libsignal-protocol/src/session_builder.rs
@@ -1,10 +1,4 @@
-use crate::{
-    address::Address,
-    context::{Context, ContextInner},
-    errors::{FromInternalErrorCode, InternalError},
-    pre_key_bundle::PreKeyBundle,
-    store_context::{StoreContext, StoreContextInner},
-};
+use crate::{address::Address, Error, context::{Context, ContextInner}, errors::{FromInternalErrorCode}, pre_key_bundle::PreKeyBundle, store_context::{StoreContext, StoreContextInner}};
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,
@@ -50,13 +44,13 @@ impl SessionBuilder {
     pub fn process_pre_key_bundle(
         &self,
         pre_key_bundle: &PreKeyBundle,
-    ) -> Result<(), InternalError> {
+    ) -> Result<(), Error> {
         unsafe {
-            sys::session_builder_process_pre_key_bundle(
+            Ok(sys::session_builder_process_pre_key_bundle(
                 self.raw,
                 pre_key_bundle.raw.as_ptr(),
             )
-            .into_result()
+            .into_result()?)
         }
     }
 }

--- a/libsignal-protocol/src/session_cipher.rs
+++ b/libsignal-protocol/src/session_cipher.rs
@@ -1,11 +1,4 @@
-use crate::{
-    context::{Context, ContextInner},
-    errors::{FromInternalErrorCode, InternalError},
-    messages::{CiphertextMessage, PreKeySignalMessage, SignalMessage},
-    raw_ptr::Raw,
-    store_context::{StoreContext, StoreContextInner},
-    Address, Buffer,
-};
+use crate::{Address, Buffer, Error, context::{Context, ContextInner}, errors::{FromInternalErrorCode}, messages::{CiphertextMessage, PreKeySignalMessage, SignalMessage}, raw_ptr::Raw, store_context::{StoreContext, StoreContextInner}};
 
 use std::{
     fmt::{self, Debug, Formatter},
@@ -27,7 +20,7 @@ impl SessionCipher {
         ctx: &Context,
         store_ctx: &StoreContext,
         address: &Address,
-    ) -> Result<SessionCipher, InternalError> {
+    ) -> Result<SessionCipher, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::session_cipher_create(
@@ -51,7 +44,7 @@ impl SessionCipher {
     pub fn encrypt(
         &self,
         message: &[u8],
-    ) -> Result<CiphertextMessage, InternalError> {
+    ) -> Result<CiphertextMessage, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::session_cipher_encrypt(
@@ -73,7 +66,7 @@ impl SessionCipher {
     pub fn decrypt_pre_key_message(
         &self,
         message: &PreKeySignalMessage,
-    ) -> Result<Buffer, InternalError> {
+    ) -> Result<Buffer, Error> {
         unsafe {
             let mut buffer = ptr::null_mut();
             sys::session_cipher_decrypt_pre_key_signal_message(
@@ -92,7 +85,7 @@ impl SessionCipher {
     pub fn decrypt_message(
         &self,
         message: &SignalMessage,
-    ) -> Result<Buffer, InternalError> {
+    ) -> Result<Buffer, Error> {
         unsafe {
             let mut buffer = ptr::null_mut();
             sys::session_cipher_decrypt_signal_message(

--- a/libsignal-protocol/src/session_cipher.rs
+++ b/libsignal-protocol/src/session_cipher.rs
@@ -1,4 +1,11 @@
-use crate::{Address, Buffer, Error, context::{Context, ContextInner}, errors::{FromInternalErrorCode}, messages::{CiphertextMessage, PreKeySignalMessage, SignalMessage}, raw_ptr::Raw, store_context::{StoreContext, StoreContextInner}};
+use crate::{
+    context::{Context, ContextInner},
+    errors::FromInternalErrorCode,
+    messages::{CiphertextMessage, PreKeySignalMessage, SignalMessage},
+    raw_ptr::Raw,
+    store_context::{StoreContext, StoreContextInner},
+    Address, Buffer, Error,
+};
 
 use std::{
     fmt::{self, Debug, Formatter},
@@ -41,10 +48,7 @@ impl SessionCipher {
     }
 
     /// Encrypt a message.
-    pub fn encrypt(
-        &self,
-        message: &[u8],
-    ) -> Result<CiphertextMessage, Error> {
+    pub fn encrypt(&self, message: &[u8]) -> Result<CiphertextMessage, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::session_cipher_encrypt(

--- a/libsignal-protocol/src/store_context.rs
+++ b/libsignal-protocol/src/store_context.rs
@@ -1,10 +1,4 @@
-use crate::{
-    context::ContextInner,
-    errors::{FromInternalErrorCode, InternalError},
-    keys::{PreKey, SessionSignedPreKey},
-    raw_ptr::Raw,
-    Address, SessionRecord,
-};
+use crate::{Address, Error, SessionRecord, context::ContextInner, InternalError, errors::{FromInternalErrorCode}, keys::{PreKey, SessionSignedPreKey}, raw_ptr::Raw};
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,
@@ -30,7 +24,7 @@ impl StoreContext {
     }
 
     /// Store pre key
-    pub fn store_pre_key(&self, pre_key: &PreKey) -> Result<(), InternalError> {
+    pub fn store_pre_key(&self, pre_key: &PreKey) -> Result<(), Error> {
         unsafe {
             sys::signal_protocol_pre_key_store_key(
                 self.raw(),
@@ -46,7 +40,7 @@ impl StoreContext {
     pub fn store_signed_pre_key(
         &self,
         signed_pre_key: &SessionSignedPreKey,
-    ) -> Result<(), InternalError> {
+    ) -> Result<(), Error> {
         unsafe {
             sys::signal_protocol_signed_pre_key_store_key(
                 self.raw(),
@@ -59,7 +53,7 @@ impl StoreContext {
     }
 
     /// Get the registration ID.
-    pub fn registration_id(&self) -> Result<u32, InternalError> {
+    pub fn registration_id(&self) -> Result<u32, Error> {
         unsafe {
             let mut id = 0;
             sys::signal_protocol_identity_get_local_registration_id(
@@ -76,7 +70,7 @@ impl StoreContext {
     pub fn contains_session(
         &self,
         addr: &Address,
-    ) -> Result<bool, InternalError> {
+    ) -> Result<bool, Error> {
         unsafe {
             match sys::signal_protocol_session_contains_session(
                 self.raw(),
@@ -85,7 +79,7 @@ impl StoreContext {
                 0 => Ok(false),
                 1 => Ok(true),
                 code => Err(InternalError::from_error_code(code)
-                    .unwrap_or(InternalError::Unknown)),
+                    .unwrap_or(InternalError::Unknown).into()),
             }
         }
     }
@@ -94,7 +88,7 @@ impl StoreContext {
     pub fn load_session(
         &self,
         addr: &Address,
-    ) -> Result<SessionRecord, InternalError> {
+    ) -> Result<SessionRecord, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::signal_protocol_session_load_session(

--- a/libsignal-protocol/src/store_context.rs
+++ b/libsignal-protocol/src/store_context.rs
@@ -1,4 +1,10 @@
-use crate::{Address, Error, SessionRecord, context::ContextInner, InternalError, errors::{FromInternalErrorCode}, keys::{PreKey, SessionSignedPreKey}, raw_ptr::Raw};
+use crate::{
+    context::ContextInner,
+    errors::FromInternalErrorCode,
+    keys::{PreKey, SessionSignedPreKey},
+    raw_ptr::Raw,
+    Address, Error, InternalError, SessionRecord,
+};
 use std::{
     fmt::{self, Debug, Formatter},
     ptr,
@@ -67,10 +73,7 @@ impl StoreContext {
     }
 
     /// Does this store already contain a session with the provided recipient?
-    pub fn contains_session(
-        &self,
-        addr: &Address,
-    ) -> Result<bool, Error> {
+    pub fn contains_session(&self, addr: &Address) -> Result<bool, Error> {
         unsafe {
             match sys::signal_protocol_session_contains_session(
                 self.raw(),
@@ -79,16 +82,14 @@ impl StoreContext {
                 0 => Ok(false),
                 1 => Ok(true),
                 code => Err(InternalError::from_error_code(code)
-                    .unwrap_or(InternalError::Unknown).into()),
+                    .unwrap_or(InternalError::Unknown)
+                    .into()),
             }
         }
     }
 
     /// Load the session corresponding to the provided recipient.
-    pub fn load_session(
-        &self,
-        addr: &Address,
-    ) -> Result<SessionRecord, Error> {
+    pub fn load_session(&self, addr: &Address) -> Result<SessionRecord, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::signal_protocol_session_load_session(

--- a/libsignal-protocol/src/stores/identity_key_store.rs
+++ b/libsignal-protocol/src/stores/identity_key_store.rs
@@ -1,4 +1,4 @@
-use crate::{errors::InternalError, Address, Buffer};
+use crate::{Address, Buffer, Error, errors::InternalError};
 use std::{
     os::raw::{c_int, c_void},
     panic::RefUnwindSafe,
@@ -8,13 +8,13 @@ use std::{
 pub trait IdentityKeyStore: RefUnwindSafe {
     /// Get the local client's identity key pair as the tuple `(public,
     /// private)`.
-    fn identity_key_pair(&self) -> Result<(Buffer, Buffer), InternalError>;
+    fn identity_key_pair(&self) -> Result<(Buffer, Buffer), Error>;
 
     /// Get the local client's registration ID.
     ///
     /// Clients should maintain a registration ID, a random number
     /// between 1 and 16380 that's generated once at install time.
-    fn local_registration_id(&self) -> Result<u32, InternalError>;
+    fn local_registration_id(&self) -> Result<u32, Error>;
 
     /// Verify a remote client's identity key.
     ///
@@ -28,7 +28,7 @@ pub trait IdentityKeyStore: RefUnwindSafe {
         &self,
         address: Address,
         identity_key: &[u8],
-    ) -> Result<bool, InternalError>;
+    ) -> Result<bool, Error>;
 
     /// Save a remote client's identity key as trusted.
     ///
@@ -39,7 +39,7 @@ pub trait IdentityKeyStore: RefUnwindSafe {
         &self,
         address: Address,
         identity_key: &[u8],
-    ) -> Result<(), InternalError>;
+    ) -> Result<(), Error>;
 }
 
 pub(crate) fn new_vtable<I: IdentityKeyStore + 'static>(

--- a/libsignal-protocol/src/stores/identity_key_store.rs
+++ b/libsignal-protocol/src/stores/identity_key_store.rs
@@ -1,4 +1,4 @@
-use crate::{Address, Buffer, Error, errors::InternalError};
+use crate::{Address, Buffer, Error};
 use std::{
     os::raw::{c_int, c_void},
     panic::RefUnwindSafe,

--- a/libsignal-protocol/src/stores/in_memory_identity_key_store.rs
+++ b/libsignal-protocol/src/stores/in_memory_identity_key_store.rs
@@ -1,7 +1,4 @@
-use crate::{
-    keys::IdentityKeyPair, stores::IdentityKeyStore, Address, Buffer,
-    InternalError, Serializable,
-};
+use crate::{Address, Buffer, Error, InternalError, Serializable, keys::IdentityKeyPair, stores::IdentityKeyStore};
 use std::{collections::HashMap, sync::Mutex};
 
 /// An in-memory [`IdentityKeyStore`].
@@ -30,21 +27,19 @@ impl InMemoryIdentityKeyStore {
 }
 
 impl IdentityKeyStore for InMemoryIdentityKeyStore {
-    fn local_registration_id(&self) -> Result<u32, InternalError> {
+    fn local_registration_id(&self) -> Result<u32, Error> {
         Ok(self.registration_id)
     }
 
-    fn identity_key_pair(&self) -> Result<(Buffer, Buffer), InternalError> {
+    fn identity_key_pair(&self) -> Result<(Buffer, Buffer), Error> {
         let public = self
             .identity
             .public()
-            .serialize()
-            .map_err(|_| InternalError::Unknown)?;
+            .serialize()?;
         let private = self
             .identity
             .private()
-            .serialize()
-            .map_err(|_| InternalError::Unknown)?;
+            .serialize()?;
 
         Ok((public, private))
     }
@@ -53,7 +48,7 @@ impl IdentityKeyStore for InMemoryIdentityKeyStore {
         &self,
         address: Address,
         identity_key: &[u8],
-    ) -> Result<bool, InternalError> {
+    ) -> Result<bool, Error> {
         let identities = self.trusted_identities.lock().unwrap();
 
         if let Some(identity) = identities.get(&address) {
@@ -67,7 +62,7 @@ impl IdentityKeyStore for InMemoryIdentityKeyStore {
         &self,
         addr: Address,
         identity_key: &[u8],
-    ) -> Result<(), InternalError> {
+    ) -> Result<(), Error> {
         self.trusted_identities
             .lock()
             .unwrap()

--- a/libsignal-protocol/src/stores/in_memory_identity_key_store.rs
+++ b/libsignal-protocol/src/stores/in_memory_identity_key_store.rs
@@ -1,4 +1,4 @@
-use crate::{Address, Buffer, Error, InternalError, Serializable, keys::IdentityKeyPair, stores::IdentityKeyStore};
+use crate::{Address, Buffer, Error, Serializable, keys::IdentityKeyPair, stores::IdentityKeyStore};
 use std::{collections::HashMap, sync::Mutex};
 
 /// An in-memory [`IdentityKeyStore`].

--- a/libsignal-protocol/src/stores/in_memory_pre_key_stores.rs
+++ b/libsignal-protocol/src/stores/in_memory_pre_key_stores.rs
@@ -1,6 +1,6 @@
 use crate::{
     stores::{PreKeyStore, SignedPreKeyStore},
-    InternalError,
+    Error, InternalError,
 };
 use std::{
     collections::HashMap,
@@ -17,13 +17,13 @@ impl PreKeyStore for InMemoryPreKeyStore {
         self.0.load(id, writer)
     }
 
-    fn store(&self, id: u32, body: &[u8]) -> Result<(), InternalError> {
+    fn store(&self, id: u32, body: &[u8]) -> Result<(), Error> {
         self.0.store(id, body)
     }
 
     fn contains(&self, id: u32) -> bool { self.0.contains(id) }
 
-    fn remove(&self, id: u32) -> Result<(), InternalError> { self.0.remove(id) }
+    fn remove(&self, id: u32) -> Result<(), Error> { self.0.remove(id) }
 }
 
 /// An in-memory [`SignedPreKeyStore`].
@@ -35,13 +35,13 @@ impl SignedPreKeyStore for InMemorySignedPreKeyStore {
         self.0.load(id, writer)
     }
 
-    fn store(&self, id: u32, body: &[u8]) -> Result<(), InternalError> {
+    fn store(&self, id: u32, body: &[u8]) -> Result<(), Error> {
         self.0.store(id, body)
     }
 
     fn contains(&self, id: u32) -> bool { self.0.contains(id) }
 
-    fn remove(&self, id: u32) -> Result<(), InternalError> { self.0.remove(id) }
+    fn remove(&self, id: u32) -> Result<(), Error> { self.0.remove(id) }
 }
 
 #[derive(Debug, Default)]
@@ -57,7 +57,7 @@ impl Inner {
         }
     }
 
-    fn store(&self, id: u32, body: &[u8]) -> Result<(), InternalError> {
+    fn store(&self, id: u32, body: &[u8]) -> Result<(), Error> {
         self.keys.lock().unwrap().insert(id, body.to_vec());
         Ok(())
     }
@@ -66,7 +66,7 @@ impl Inner {
         self.keys.lock().unwrap().contains_key(&id)
     }
 
-    fn remove(&self, id: u32) -> Result<(), InternalError> {
+    fn remove(&self, id: u32) -> Result<(), Error> {
         self.keys.lock().unwrap().remove(&id);
         Ok(())
     }

--- a/libsignal-protocol/src/stores/in_memory_pre_key_stores.rs
+++ b/libsignal-protocol/src/stores/in_memory_pre_key_stores.rs
@@ -1,6 +1,6 @@
 use crate::{
     stores::{PreKeyStore, SignedPreKeyStore},
-    Error, InternalError,
+    Error,
 };
 use std::{
     collections::HashMap,

--- a/libsignal-protocol/src/stores/in_memory_session_store.rs
+++ b/libsignal-protocol/src/stores/in_memory_session_store.rs
@@ -1,6 +1,6 @@
 use crate::{
     stores::{SerializedSession, SessionStore},
-    Address, InternalError,
+    Address, Error, InternalError,
 };
 use std::{collections::HashMap, sync::Mutex};
 
@@ -14,7 +14,7 @@ impl SessionStore for InMemorySessionStore {
     fn load_session(
         &self,
         address: Address,
-    ) -> Result<Option<SerializedSession>, InternalError> {
+    ) -> Result<Option<SerializedSession>, Error> {
         Ok(self.sessions.lock().unwrap().get(&address).cloned())
     }
 
@@ -46,12 +46,12 @@ impl SessionStore for InMemorySessionStore {
         Ok(())
     }
 
-    fn delete_session(&self, addr: Address) -> Result<(), InternalError> {
+    fn delete_session(&self, addr: Address) -> Result<(), Error> {
         self.sessions.lock().unwrap().remove(&addr);
         Ok(())
     }
 
-    fn delete_all_sessions(&self, name: &[u8]) -> Result<usize, InternalError> {
+    fn delete_all_sessions(&self, name: &[u8]) -> Result<usize, Error> {
         let mut sessions = self.sessions.lock().unwrap();
 
         let to_delete: Vec<_> = sessions
@@ -67,7 +67,7 @@ impl SessionStore for InMemorySessionStore {
         Ok(to_delete.len())
     }
 
-    fn contains_session(&self, addr: Address) -> Result<bool, InternalError> {
+    fn contains_session(&self, addr: Address) -> Result<bool, Error> {
         Ok(self.sessions.lock().unwrap().contains_key(&addr))
     }
 }

--- a/libsignal-protocol/src/stores/pre_key_store.rs
+++ b/libsignal-protocol/src/stores/pre_key_store.rs
@@ -1,4 +1,4 @@
-use crate::{buffer::Buffer, errors::InternalError};
+use crate::{buffer::Buffer, Error, InternalError};
 use std::{
     io::{self, Write},
     os::raw::{c_int, c_void},
@@ -11,11 +11,11 @@ pub trait PreKeyStore: RefUnwindSafe {
     /// Load a pre-key.
     fn load(&self, id: u32, writer: &mut dyn Write) -> io::Result<()>;
     /// Store a pre-key.
-    fn store(&self, id: u32, body: &[u8]) -> Result<(), InternalError>;
+    fn store(&self, id: u32, body: &[u8]) -> Result<(), Error>;
     /// Is the pre-key with this ID present in the store?
     fn contains(&self, id: u32) -> bool;
     /// Remove a pre-key from the store.
-    fn remove(&self, id: u32) -> Result<(), InternalError>;
+    fn remove(&self, id: u32) -> Result<(), Error>;
 }
 
 pub(crate) fn new_vtable<P: PreKeyStore + 'static>(

--- a/libsignal-protocol/src/stores/session_store.rs
+++ b/libsignal-protocol/src/stores/session_store.rs
@@ -1,4 +1,4 @@
-use crate::{errors::InternalError, Address, Buffer};
+use crate::{Address, Buffer, Error, InternalError};
 use std::{
     os::raw::{c_char, c_int, c_void},
     panic::RefUnwindSafe,
@@ -20,7 +20,7 @@ pub trait SessionStore: RefUnwindSafe {
     fn load_session(
         &self,
         address: Address,
-    ) -> Result<Option<SerializedSession>, InternalError>;
+    ) -> Result<Option<SerializedSession>, Error>;
 
     /// Get the IDs of all known devices with active sessions for a recipient.
     fn get_sub_device_sessions(
@@ -30,7 +30,7 @@ pub trait SessionStore: RefUnwindSafe {
 
     /// Determine whether there is a committed session record for a
     /// recipient ID + device ID tuple.
-    fn contains_session(&self, addr: Address) -> Result<bool, InternalError>;
+    fn contains_session(&self, addr: Address) -> Result<bool, Error>;
 
     /// Commit to storage the session record for a given recipient ID + device
     /// ID tuple.
@@ -41,13 +41,13 @@ pub trait SessionStore: RefUnwindSafe {
     ) -> Result<(), InternalError>;
 
     /// Remove a session record for a recipient ID + device ID tuple.
-    fn delete_session(&self, addr: Address) -> Result<(), InternalError>;
+    fn delete_session(&self, addr: Address) -> Result<(), Error>;
 
     /// Remove the session records corresponding to all devices of a recipient
     /// ID.
     ///
     /// Returns the number of deleted sessions.
-    fn delete_all_sessions(&self, name: &[u8]) -> Result<usize, InternalError>;
+    fn delete_all_sessions(&self, name: &[u8]) -> Result<usize, Error>;
 }
 
 pub(crate) fn new_vtable<S: SessionStore + 'static>(

--- a/libsignal-protocol/src/stores/signed_pre_key_store.rs
+++ b/libsignal-protocol/src/stores/signed_pre_key_store.rs
@@ -1,4 +1,4 @@
-use crate::{buffer::Buffer, errors::InternalError};
+use crate::{buffer::Buffer, Error, InternalError};
 use std::{
     io::{self, Write},
     os::raw::{c_int, c_void},
@@ -10,11 +10,11 @@ pub trait SignedPreKeyStore: RefUnwindSafe {
     /// Load a signed pre-key.
     fn load(&self, id: u32, writer: &mut dyn Write) -> io::Result<()>;
     /// Store a signed pre-key.
-    fn store(&self, id: u32, body: &[u8]) -> Result<(), InternalError>;
+    fn store(&self, id: u32, body: &[u8]) -> Result<(), Error>;
     /// Is the signed pre-key with this ID present in the store?
     fn contains(&self, id: u32) -> bool;
     /// Remove a signed pre-key from the store.
-    fn remove(&self, id: u32) -> Result<(), InternalError>;
+    fn remove(&self, id: u32) -> Result<(), Error>;
 }
 
 pub(crate) fn new_vtable<P>(

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -12,8 +12,7 @@ use sig::{
         InMemoryIdentityKeyStore, InMemoryPreKeyStore, InMemorySessionStore,
         InMemorySignedPreKeyStore,
     },
-    Address, Context, Deserializable, PreKeyBundle,
-    Serializable,
+    Address, Context, Deserializable, PreKeyBundle, Serializable,
 };
 
 use crate::helpers::{fake_random_generator, MockCrypto};

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use sig::{
+    Error, InternalError,
     keys::{PrivateKey, PublicKey},
     messages::{PreKeySignalMessage, SignalMessage},
     stores::{
@@ -312,7 +313,10 @@ fn test_basic_pre_key_v2() {
     // Have Alice process Bob's pre key bundle, which should fail due to a
     // missing unsigned pre key.
     let got = alice_session_builder.process_pre_key_bundle(&bob_pre_key_bundle);
-    assert!(got.is_err());
+    assert!(match got {
+        Err(Error::InternalError(InternalError::InvalidKey)) => true,
+        _ => false
+    }, "result is not InternalError::InvalidKey");
 }
 
 #[test]

--- a/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
+++ b/libsignal-protocol/tests/libsignal-protocol-c-tests.rs
@@ -12,7 +12,7 @@ use sig::{
         InMemoryIdentityKeyStore, InMemoryPreKeyStore, InMemorySessionStore,
         InMemorySignedPreKeyStore,
     },
-    Address, Context, Deserializable, InternalError, PreKeyBundle,
+    Address, Context, Deserializable, PreKeyBundle,
     Serializable,
 };
 
@@ -313,7 +313,7 @@ fn test_basic_pre_key_v2() {
     // Have Alice process Bob's pre key bundle, which should fail due to a
     // missing unsigned pre key.
     let got = alice_session_builder.process_pre_key_bundle(&bob_pre_key_bundle);
-    assert_eq!(got, Err(InternalError::InvalidKey));
+    assert!(got.is_err());
 }
 
 #[test]


### PR DESCRIPTION
`InternalError` was already using `thiserror`, so this commit finishes transitioning away from `failure` which means errors can now be better handled in downstream code.

I forgot to mention that the most useful part for me here, is that `Error::IoError` implements `From<std::io::Error>` as most `stores` trait implementations will have to deal with some I/O operations.

TODO:
- [x] Use the new `Error` in all the store traits
- [x] Prepare MR to `libsignal-service-rs` at the same time, with all the necessary fixes. Done, see https://github.com/Michael-F-Bryan/libsignal-service-rs/pull/19