### PR TITLE
Add to_bytes() to PublicKey and PrivateKey

### DIFF
--- a/libsignal-protocol/src/keys/private.rs
+++ b/libsignal-protocol/src/keys/private.rs
@@ -61,7 +61,7 @@ impl PrivateKey {
     }
 
     /// Return this private key as a base64 encoded string.
-    pub fn as_base64(&self) -> Result<String, Error> {
+    pub fn to_base64(&self) -> Result<String, Error> {
         Ok(base64::encode(self.to_bytes()?))
     }
 }

--- a/libsignal-protocol/src/keys/private.rs
+++ b/libsignal-protocol/src/keys/private.rs
@@ -50,14 +50,19 @@ impl PrivateKey {
         }
     }
 
-    /// returns this private key as a base64 encoded string
-    pub fn as_base64(&self) -> Result<String, Error> {
+    /// Get a copy of to the underlying private key data.
+    pub fn to_bytes(&self) -> Result<Buffer, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::ec_private_key_serialize(&mut raw, self.raw.as_const_ptr())
                 .into_result()?;
-            Ok(base64::encode(Buffer::from_raw(raw).as_slice()))
+            Ok(Buffer::from_raw(raw))
         }
+    }
+
+    /// Return this private key as a base64 encoded string.
+    pub fn as_base64(&self) -> Result<String, Error> {
+        Ok(base64::encode(self.to_bytes()?))
     }
 }
 

--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -91,14 +91,19 @@ impl PublicKey {
         }
     }
 
-    /// returns this public key as a base64 encoded string
-    pub fn as_base64(&self) -> Result<String, InternalError> {
+    /// Get a copy of to the underlying private key data.
+    pub fn to_bytes(&self) -> Result<Buffer, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
             sys::ec_public_key_serialize(&mut raw, self.raw.as_const_ptr())
                 .into_result()?;
-            Ok(base64::encode(Buffer::from_raw(raw).as_slice()))
+            Ok(Buffer::from_raw(raw))
         }
+    }
+
+    /// Return this public key as a base64 encoded string.
+    fn as_base64(&self) -> Result<String, Error> {
+        Ok(base64::encode(self.to_bytes()?))
     }
 }
 

--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -102,7 +102,7 @@ impl PublicKey {
     }
 
     /// Return this public key as a base64 encoded string.
-    fn as_base64(&self) -> Result<String, Error> {
+    fn to_base64(&self) -> Result<String, Error> {
         Ok(base64::encode(self.to_bytes()?))
     }
 }
@@ -142,7 +142,7 @@ impl PartialOrd for PublicKey {
 
 impl Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.as_base64().map_err(|_| fmt::Error)?)
+        f.write_str(&self.to_base64().map_err(|_| fmt::Error)?)
     }
 }
 


### PR DESCRIPTION
This is important to avoid unnecessary conversions when using the raw data public & private keys.