### PR TITLE
PublicKey::to_base64 should be public

### DIFF
--- a/libsignal-protocol/src/keys/public.rs
+++ b/libsignal-protocol/src/keys/public.rs
@@ -102,7 +102,7 @@ impl PublicKey {
     }
 
     /// Return this public key as a base64 encoded string.
-    fn to_base64(&self) -> Result<String, Error> {
+    pub fn to_base64(&self) -> Result<String, Error> {
         Ok(base64::encode(self.to_bytes()?))
     }
 }


### PR DESCRIPTION
Missing from https://github.com/Michael-F-Bryan/libsignal-protocol-rs/pull/73