### PR TITLE
Fixup compilation for non x86_64 targets where c_char = u8

### DIFF
--- a/libsignal-protocol/src/store_context.rs
+++ b/libsignal-protocol/src/store_context.rs
@@ -117,7 +117,7 @@ impl StoreContext {
             sys::signal_protocol_session_get_sub_device_sessions(
                 self.raw(),
                 &mut sessions,
-                identifier.as_ptr() as *const i8,
+                identifier.as_ptr() as *const ::std::os::raw::c_char,
                 identifier.len(),
             )
             .into_result()?;


### PR DESCRIPTION
Fixes 

```
   Compiling libsignal-protocol v0.1.1-alpha.0 (https://github.com/Michael-F-Bryan/libsignal-protocol-rs#40490f95)
error[E0308]: mismatched types
   --> /home/rsmet/.cargo/git/checkouts/libsignal-protocol-rs-bd2698d95a103c0d/40490f9/libsignal-protocol/src/store_context.rs:120:17
    |
120 |                 identifier.as_ptr() as *const i8,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
```