### PR TITLE
Add SessionContext::get_identity

### DIFF
--- a/libsignal-protocol/src/messages/ciphertext_message.rs
+++ b/libsignal-protocol/src/messages/ciphertext_message.rs
@@ -35,7 +35,7 @@ pub struct CiphertextMessage {
 
 impl CiphertextMessage {
     /// Which type of message is this?
-    pub fn get_type(&self) -> Result<CiphertextType, InternalError> {
+    pub fn get_type(&self) -> Result<CiphertextType, Error> {
         unsafe {
             let ty = sys::ciphertext_message_get_type(self.raw.as_ptr());
 
@@ -46,7 +46,9 @@ impl CiphertextMessage {
                 sys::CIPHERTEXT_SENDERKEY_DISTRIBUTION_TYPE => {
                     Ok(CiphertextType::SenderKeyDistribution)
                 }
-                other => Err(InternalError::UnknownCiphertextType(other)),
+                other => {
+                    Err(InternalError::UnknownCiphertextType(other).into())
+                }
             }
         }
     }

--- a/libsignal-protocol/src/messages/signal_message.rs
+++ b/libsignal-protocol/src/messages/signal_message.rs
@@ -68,7 +68,7 @@ impl SignalMessage {
         receiver_identity_key: &PublicKey,
         mac: &[u8],
         ctx: &Context,
-    ) -> Result<bool, InternalError> {
+    ) -> Result<bool, Error> {
         unsafe {
             let code = sys::signal_message_verify_mac(
                 self.raw.as_ptr(),
@@ -83,7 +83,8 @@ impl SignalMessage {
                 0 => Ok(false),
                 1 => Ok(true),
                 other => Err(InternalError::from_error_code(other)
-                    .unwrap_or(InternalError::Unknown)),
+                    .unwrap_or(InternalError::Unknown)
+                    .into()),
             }
         }
     }

--- a/libsignal-protocol/src/stores/in_memory_identity_key_store.rs
+++ b/libsignal-protocol/src/stores/in_memory_identity_key_store.rs
@@ -67,4 +67,13 @@ impl IdentityKeyStore for InMemoryIdentityKeyStore {
 
         Ok(())
     }
+
+    fn get_identity(&self, addr: Address) -> Result<Option<Buffer>, Error> {
+        Ok(self
+            .trusted_identities
+            .lock()
+            .unwrap()
+            .get(&addr)
+            .and_then(|i| Some(Buffer::from(i.clone()))))
+    }
 }


### PR DESCRIPTION
The function is required to implement the `SealedSessionCipher` and can be found in [libsignal-protocol-java](https://github.com/signalapp/libsignal-protocol-java/blob/ea0ffa41ec945836e44b9472c43467f9c6c1810c/java/src/main/java/org/whispersystems/libsignal/state/IdentityKeyStore.java#L80) but not in `libsignal-protocol-c`.

Options: do this, or try to add the missing function in `libsignal-protocol-c` or... both (and undo this change later)